### PR TITLE
add info logging and remove unnecessary imports loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ import TodosCollection from 'js/models/todos-collection';
 
 ResourceKeys.add({TODOS: 'todos'});
 ModelMap.add({[ResourceKeys.TODOS]: TodosCollection});
+
+// in your top level js file
+import 'js/core/with-resources-config;
 ```
 
 3. Use `withResources` to request your models in any component:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -30,9 +30,6 @@ module.exports = (config) => {
           test: /\.jsx?$/,
           exclude: /node_modules/,
           use: {loader: 'babel-loader?cacheDirectory=true'}
-        }, {
-          test: /schmackbone.js$/,
-          use: 'imports-loader?define=>false'
         }]
       }
     }

--- a/lib/error-boundary.js
+++ b/lib/error-boundary.js
@@ -34,7 +34,7 @@ export default class ErrorBoundary extends React.Component {
   componentDidCatch(err, info) {
     this.setState({caughtError: true});
     // hook to allow custom error reporting for an application
-    ResourcesConfig.log(err);
+    ResourcesConfig.log(err, info);
   }
 
   render() {


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

An issue where the second parameter from the `componentDidCatch` lifecycle method was not getting passed along to the logger.

## Description of Proposed Changes:  
  -  passes all `componentDidCatch` arguments to the logger
  -  updates docs
  -  removes unnecessary schmackbone import shim, since we now transpile before publishing
