### PR TITLE
know exactly which argument to use

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,4 +1,5 @@
 import ModelCache from './model-cache';
+import Schmackbone from 'schmackbone';
 
 const loadingCache = {};
 
@@ -64,7 +65,7 @@ export default (key, Model, options={}) => {
   if (!loadingCache[key]) {
     _promise = new Promise((resolve, reject) => {
       if (!model || options.forceFetch) {
-        model = model || new Model(options.models || options.attributes, options.options || {});
+        model = model || new Model(options[getFirstArgPropertyName(Model)], options.options || {});
         ModelCache.put(key, model, options.component);
 
         if (options.fetch) {
@@ -119,3 +120,14 @@ export default (key, Model, options={}) => {
   // this way we can attach more .then() handlers
   return loadingCache[key];
 };
+
+/**
+ * Helper to determine whether to pass the `models` property or the `attributes`
+ * value of an options hash as a model instantiation's first argument.
+ *
+ * @param {Schmackbone.Model|Schmackbone.Collection} Constructor - model constructor
+ * @return {string} property name to pass to model instantiation
+ */
+function getFirstArgPropertyName(Constructor) {
+  return Constructor.prototype instanceof Schmackbone.Collection ? 'models' : 'attributes';
+}


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

An issue where `attributes` were not getting passed to model instantiating because the default `models` was a truthy empty array.

## Description of Proposed Changes:  
  -  uses the 'models' or 'attributes' not by inference but by whether the model is a Collection or Model Type
