### PR TITLE
resourcerer rename

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,6 @@ jobs:
 
 workflows:
   version: 2
-  with-resources:
+  resourcerer:
     jobs:
       - test

--- a/ADVANCED_TOPICS.md
+++ b/ADVANCED_TOPICS.md
@@ -1,6 +1,6 @@
 ## Thoughts on the PENDING Resource
 
-Using `dependsOn` in simple cases like the one highlighted in the [README](https://github.com/SiftScience/with-resources/blob/master/README.md) is pretty straightforward and very powerful. But `PENDING` resources bring additional complexities to your resource logic, some of which are enumerated here:
+Using `dependsOn` in simple cases like the one highlighted in the [README](https://github.com/SiftScience/resourcerer/blob/master/README.md) is pretty straightforward and very powerful. But `PENDING` resources bring additional complexities to your resource logic, some of which are enumerated here:
 
 
 1. `PENDING` critical resources don’t contribute to `isLoading`/`hasErrored` states, but will keep your component from reaching a `hasLoaded` state. Semantically, this makes sense, because `this.props.hasLoaded` should only be true when all critical resources have loaded, regardless of when a resource’s request is made.
@@ -84,11 +84,11 @@ For all other uses of dependent resources, we should use `dependsOn`.
 
 ## Unfetched Resources
 
-You may find, at some point in your application, that you have a `PUT` endpoint for a resource but no `GET`; the 'read portion' of the resource is received as part of some parent resource. For example, imagine you have an accounts resource at `/accounts/{account_id}`, whose response has a `config` property with some account configuration settings. To update the configuration, you make a `PUT` to `/accounts/{account_id}/config`. But reading comes from the parent resource. `with-resources` supports this via a `providesModels` static property on the model:
+You may find, at some point in your application, that you have a `PUT` endpoint for a resource but no `GET`; the 'read portion' of the resource is received as part of some parent resource. For example, imagine you have an accounts resource at `/accounts/{account_id}`, whose response has a `config` property with some account configuration settings. To update the configuration, you make a `PUT` to `/accounts/{account_id}/config`. But reading comes from the parent resource. `resourcerer` supports this via a `providesModels` static property on the model:
 
 ```js
 // resources_conifg.js
-import {ResourceKeys, UnfetchedResources} from 'with-resources/config';
+import {ResourceKeys, UnfetchedResources} from 'resourcerer/config';
 
 ResourceKeys.add({
   ACCOUNT: 'account',
@@ -118,7 +118,7 @@ export default Backbone.Model.extend({
 })
 ```
 
-The `providesModels` property is a function that takes the parent model and the `ResourceKeys` as arguments and returns an array of resource configs. The resource configs have the same schema as the those used in our general `withResources` executor functions. What this tells `with-resources` to do is, after the parent model returns, instantiate the child model(s) and place them into the `ModelCache`. In other components, you can then access the model you know to exist in a `withResources` declaration:
+The `providesModels` property is a function that takes the parent model and the `ResourceKeys` as arguments and returns an array of resource configs. The resource configs have the same schema as the those used in our general `withResources` executor functions. What this tells `resourcerer` to do is, after the parent model returns, instantiate the child model(s) and place them into the `ModelCache`. In other components, you can then access the model you know to exist in a `withResources` declaration:
 
 ```js
 // child_component.jsx, rendered only after the account model is known to return
@@ -134,7 +134,7 @@ class ChildComponent extends React.Component {
 }
 ```
 
-In general, this should be used in cases where you can ascertain that the parent model has returned before trying to access the child model. However, if by chance it has not, and the child is not found in the cache, `with-resources` will still not attempt to fetch it, because it is listed within the `UnfetchedResources` set. In that case, the model will get instantiated with no seed attributes and passed as a prop.
+In general, this should be used in cases where you can ascertain that the parent model has returned before trying to access the child model. However, if by chance it has not, and the child is not found in the cache, `resourcerer` will still not attempt to fetch it, because it is listed within the `UnfetchedResources` set. In that case, the model will get instantiated with no seed attributes and passed as a prop.
 
 Also, note that the `modelKey` property is required here instead of optionally being inferred from the resource config's object property, as is the case in our general `withResources` declarations. This is because here, in contrast, the models are simply placed in the cache and not actually used as props for any component, so they don't need to be named. Accordingly, resource configs are also returned as a list here instead of an object.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to `with-resources`
+# Contributing to `resourcerer`
 
 Please use the following guidelines when contributing to this repository:
 
@@ -10,15 +10,15 @@ Please use the following guidelines when contributing to this repository:
 
 
 ## Conduct
-See our [Code of Conduct](https://github.com/SiftScience/with-resources/CODE_OF_CONDUCT.md) page.  
+See our [Code of Conduct](https://github.com/SiftScience/resourcerer/CODE_OF_CONDUCT.md) page.  
 
 
 ## Clone the repo
 To get started in development, clone the repository and install dependencies:
   
 ```sh
-$ git clone git@github.com:SiftScience/with-resources.git
-$ cd with-resources
+$ git clone git@github.com:SiftScience/resourcerer.git
+$ cd resourcerer
 $ npm i
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# with-resources
+# resourcerer
 
-![CircleCI](https://circleci.com/gh/SiftScience/with-resources/tree/master.svg?style=svg&circle-token=45a34426d0ed2c954ed07b8ce27248aa6f93cb06)
+![CircleCI](https://circleci.com/gh/SiftScience/resourcerer/tree/master.svg?style=svg&circle-token=45a34426d0ed2c954ed07b8ce27248aa6f93cb06)
 
-`with-resources` is a very powerful higher-order React component (HOC) for declaratively fetching and caching your application's data. It allows you to easily construct a component's data flow, including:
+`resourcerer` is a very powerful higher-order React component (HOC) for declaratively fetching and caching your application's data. It allows you to easily construct a component's data flow, including:
 
 * serial requests
 * prioritized rendering for critical data (enabling less critical or slower requests to not block interactivity)
@@ -30,22 +30,22 @@ export default Schmackbone.Collection.extend({url: () => '/todos'});
 2. Create a config file in your application, add a key for your model, and link it to your model constructor:
 
 ```js
-// js/core/with-resources-config.js
-import {ModelMap, ResourceKeys} from 'with-resources/config';
+// js/core/resourcerer-config.js
+import {ModelMap, ResourceKeys} from 'resourcerer/config';
 import TodosCollection from 'js/models/todos-collection';
 
 ResourceKeys.add({TODOS: 'todos'});
 ModelMap.add({[ResourceKeys.TODOS]: TodosCollection});
 
 // in your top level js file
-import 'js/core/with-resources-config;
+import 'js/core/resourcerer-config;
 ```
 
 3. Use `withResources` to request your models in any component:
 
 ```jsx
 import React from 'react';
-import withResources from 'with-resources';
+import {withResources} from 'resourcerer';
 
 @withResources((props, ResourceKeys) => ({[ResourceKeys.TODOS]: {}}))
 class MyComponent extends React.Component {
@@ -94,17 +94,17 @@ There's a lot there, so let's unpack that a bit. There's also a lot more that we
         1. [attributes](#attributes)
     1. [Caching Resources with ModelCache](#caching-resources-with-modelcache)
     1. [Declarative Cache Keys](#declarative-cache-keys)
-1. [Configuring with-resources](#configuring-with-resources)
+1. [Configuring resourcerer](#configuring-resourcerer)
 1. [FAQs](#faqs)
 
 
 # Installation
 
-`$ npm i with-resources`
+`$ npm i resourcerer`
 
-`with-resources` depends on React >= 16 and Schmackbone (which itself depends on [Underscore](https://github.com/jashkenas/underscore) and [qs](https://github.com/ljharb/qs)).
+`resourcerer` depends on React >= 16 and Schmackbone (which itself depends on [Underscore](https://github.com/jashkenas/underscore) and [qs](https://github.com/ljharb/qs)).
 
-The `with-resources` package is compiled into ESNext, with only its [legacy, Stage-1 decorators](https://github.com/tc39/proposal-decorators/blob/master/previous/METAPROGRAMMING.md),
+The `resourcerer` package is compiled into ESNext, with only its [legacy, Stage-1 decorators](https://github.com/tc39/proposal-decorators/blob/master/previous/METAPROGRAMMING.md),
 object spread, and ES2015 module syntax transpiled. If you need to target older browsers, you can incorporate this package into your own build system to transpile further.
 
 Also worth noting is that this package does not do any bundling into a single file, instead letting the user use whatever bundler they like.
@@ -124,8 +124,8 @@ takes two arguments: the current props, and an object of `ResourceKeys`. Where d
 from? From the config file we added to earlier!
 
 ```js
-// js/core/with-resources-config.js
-import {ModelMap, ResourceKeys} from 'with-resources/config';
+// js/core/resourcerer-config.js
+import {ModelMap, ResourceKeys} from 'resourcerer/config';
 import TodosCollection from 'js/models/todos-collection';
 
 // after adding this key, `ResourceKeys.TODOS` will be used in our executor functions to reference
@@ -149,7 +149,7 @@ Back to the executor function. In the example above, you see it returns an objec
 Of course, in our initial example, the todos collection won’t get passed down immediately since, after all, the resource has to be fetched from API3.  Some of the most **critical** and most common React UI states we utilize are whether a component’s critical resources have loaded entirely, whether any are still loading, or whether any have errored out. This is how we can appropriately cover our bases&mdash;i.e., we can ensure the component shows a loader while the resource is still in route, or if something goes wrong, we can ensure the component will still fail gracefully and not break the layout. To address these concerns, `withResources` gives you several loading state helper props. From our last example:
 
 
-- `this.props.todosLoadingState` (can be equal to any of the [LoadingStates constants](https://github.com/SiftScience/with-resources/blob/master/lib/constants.js), and there will be one for each resource)
+- `this.props.todosLoadingState` (can be equal to any of the [LoadingStates constants](https://github.com/SiftScience/resourcerer/blob/master/lib/constants.js), and there will be one for each resource)
 - `this.props.hasLoaded` {boolean} - all critical resources have successfully completed and are ready to be used by the component
 - `this.props.isLoading` {boolean} - any of the critical resources are still in the process of being fetched
 - `this.props.hasErrored` {boolean} - any of the critical resource requests did not complete successfully
@@ -178,7 +178,7 @@ Here’s how might use that to our advantage in `MyClassWithTodosAndAUsers` :
 
 ```jsx
 // pure functions that accept loading states as arguments
-import {hasLoaded} from 'with-resources/utils';
+import {hasLoaded} from 'resourcerer/utils';
 
 // ...
     render() {
@@ -235,8 +235,8 @@ There’s one other loading prop passed down from `withResources`: `this.props.h
 Let's say we wanted to request not the entire users collection, but just a specific user. Here's our config:
 
 ```js
-// js/core/with-resources-config.js
-import {ModelMap, ResourceKeys} from 'with-resources/config';
+// js/core/resourcerer-config.js
+import {ModelMap, ResourceKeys} from 'resourcerer/config';
 import TodosCollection from 'js/models/todos-collection';
 import UserModel from 'js/models/user-model';
 
@@ -330,7 +330,7 @@ Finally, if a model is to provide more than a single prop, use an underscore ins
     },
     [QUEUE_ITEM]: {
       attributes: {id: props.itemId}
-      // use an underscore here to tell with-resources to spread the resulting object
+      // use an underscore here to tell resourcerer to spread the resulting object
       provides: {_: getUserDataFromItem}
     }
   }))
@@ -377,7 +377,7 @@ As alluded to in the [Other Props](#other-props-passed-from-the-hoc-loading-stat
 
 - De-prioritize fetching the resource until after all critical resources have been fetched
 - Remove the resource from consideration within the component-wide loading states (`props.hasLoaded`, `props.isLoading`, `props.hasErrored`), giving us the ability to render without waiting on those resources
-- Can set our own UI logic around displaying noncritical data based on their individual loading states, ie `props.usersLoadingState`, which can be passed to the pure helper methods, `hasLoaded`, `hasErrored`, and `isLoading` from `with-resources/utils`.
+- Can set our own UI logic around displaying noncritical data based on their individual loading states, ie `props.usersLoadingState`, which can be passed to the pure helper methods, `hasLoaded`, `hasErrored`, and `isLoading` from `resourcerer/utils`.
   
   
 ### listen
@@ -536,12 +536,12 @@ The generated cache key would be something like `userTodos_limit=50_$range=86400
 - the `range` value is taken from a function that takes `start_millis`/`end_millis` from the `data` hash into account.
 
 
-# Configuring `with-resources`
+# Configuring `resourcerer`
 
 The same config file used to add to `ResourceKeys` and `ModelMap` also allows you to set custom configuration properties for your own application:
 
 ```js
-import {ResourcesConfig} from 'with-resources/config';
+import {ResourcesConfig} from 'resourcerer/config';
 
 ResourcesConfig.set(configObj);
 ```
@@ -579,30 +579,30 @@ ResourcesConfig.set(configObj);
 
     Yeah...isn't [GraphQL](https://graphql.org/) the thing to use now? Why bother with a library for REST APIs&mdash;especially one that is based on a _Backbone_ fork. It feels so...._2012_.
     
-    GraphQL is awesome, but there are many reasons why you might not want to use it. Maybe you don't have the resources to ensure that all of your data can be accessed performantly; in that case, your single `/graphql` endpoint will only ever be as fast as your slowest data source. Maybe your existing REST API is working well and your eng org isn't going to prioritize any time to move away from it. Etc, etc, etc. `with-resources` offers a way for your front-end team to quickly get up and running with declarative data fetching, request flows, and model caching.
+    GraphQL is awesome, but there are many reasons why you might not want to use it. Maybe you don't have the resources to ensure that all of your data can be accessed performantly; in that case, your single `/graphql` endpoint will only ever be as fast as your slowest data source. Maybe your existing REST API is working well and your eng org isn't going to prioritize any time to move away from it. Etc, etc, etc. `resourcerer` offers a way for your front-end team to quickly get up and running with declarative data fetching, request flows, and model caching.
 
-* Does `with-resources` support SSR?  
+* Does `resourcerer` support SSR?  
   
-    There is no official documentation for its use in server-side rendering at this point. However, because passing models as props directly to a component [bypasses fetching](/TESTING_COMPONENTS.md#testing-components-that-use-withresources), it is likely that `with-resources` can work nicely with an SSR setup that:  
+    There is no official documentation for its use in server-side rendering at this point. However, because passing models as props directly to a component [bypasses fetching](/TESTING_COMPONENTS.md#testing-components-that-use-withresources), it is likely that `resourcerer` can work nicely with an SSR setup that:  
     
     1. passes instantiated models directly through the app before calling `renderToString`  
     2. provides those models within a top-level `<script>` element that adds them directly to the [ModelCache](#caching-resources-with-modelcache).
 
 * Does it support async rendering?  
   
-    For the initial release, `with-resources` still employs one instance of `UNSAFE_componentWillReceiveProps` to set loading states prior to fetching a new resource. The benefit of doing this there instead of `componentDidUpdate` is that it avoids an extra render caused by setting state after an update has happened. The downside is that it prevents `with-resources`, for now, from safely using some of React's newer APIs, such as asynchronous rendering with Suspense. Full disclosure: I am sad that `componentWillReceiveProps` has been deprecated, and I would much prefer to keep it and have the React team trust developers not to put side effects in it. But I still think it has an important place in preventing extra renders. [getDerivedStateFromProps](https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops) does not allow you to compare previous to next without doing some state hackery.
+    For the initial release, the `withResources` HOC still employs one instance of `UNSAFE_componentWillReceiveProps` to set loading states prior to fetching a new resource. The benefit of doing this there instead of `componentDidUpdate` is that it avoids an extra render caused by setting state after an update has happened. The downside is that it prevents `withResources`, for now, from safely using some of React's newer APIs, such as asynchronous rendering with Suspense. Full disclosure: I am sad that `componentWillReceiveProps` has been deprecated, and I would much prefer to keep it and have the React team trust developers not to put side effects in it. But I still think it has an important place in preventing extra renders. [getDerivedStateFromProps](https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops) does not allow you to compare previous to next without doing some state hackery.
     
     * ...can this be turned into a React Hook?
     
-        I bet it can. React Hooks are exciting! However, they're also brand new, and the React team is still not recommending using them on production sites. As we are more concerned with stability and production-readiness in this package, `with-resources` is a good-ol' higher-order component that wraps an 'old-school' React class component (it uses refs and thus wrapping function components will not work). But! The good news is that this library has been used at [Sift](https://sift.com) to power its [console](https://console.sift.com) for two years now, and so for us, it is tried and true (we'll see if it is tried and true for others!).
+        I bet it can. React Hooks are exciting! However, they're also brand new, and the React team is still not recommending using them on production sites. As we are more concerned with stability and production-readiness in this package, `withResources` is a good-ol' higher-order component that wraps an 'old-school' React class component (it uses refs and thus wrapping function components will not work). But! The good news is that this library has been used at [Sift](https://sift.com) to power its [console](https://console.sift.com) for two years now, and so for us, it is tried and true (we'll see if it is tried and true for others!).
         
-* Can `with-resources` be used with both function components and class components?
+* Can the `withResources` HOC be used with both function components and class components?
 
     No (see previous answer above). Because it uses refs, it must wrap a React class component.
 
-* Can `with-resources` do anything other than `GET` requests?
+* Can `withResources` do anything other than `GET` requests?
 
-    `with-resources` only handles resource _fetching_ (i.e. calling [Schmackbone.Model.prototype.fetch](https://backbonejs.org/#Model-fetch)). Note that this is not the same as only making `GET` requests; pass in a `method: 'POST'` property in a resource's config to turn the `data` property into a POST body, for example, when making a search request.
+    `withResources` only handles resource _fetching_ (i.e. calling [Schmackbone.Model.prototype.fetch](https://backbonejs.org/#Model-fetch)). Note that this is not the same as only making `GET` requests; pass in a `method: 'POST'` property in a resource's config to turn the `data` property into a POST body, for example, when making a search request.
     
     For write operations, use Schmackbone Models' [`save`](https://backbonejs.org/#Model-savehttps://backbonejs.org/#Model-save) and [`destroy`](https://backbonejs.org/#Model-destroy) methods directly:
     
@@ -622,13 +622,13 @@ ResourcesConfig.set(configObj);
 
 * What about other data sources like websockets?  
 
-    `with-resources` supports request/response-style semantics only. A similar package for declaratively linking message-pushing to React updates would be awesome&mdash;but it is not, at this point, part of this package.
+    `resourcerer` supports request/response-style semantics only. A similar package for declaratively linking message-pushing to React updates would be awesome&mdash;but it is not, at this point, part of this package.
 
-* How can we test components that use `with-resources`?  
+* How can we test components that use `resourcerer`?  
   
     See the [doc on testing components](/TESTING_COMPONENTS.md) for more on that.
 
-* How big is the `with-resources` package?  
+* How big is the `resourcerer` package?  
 
     4kB gzipped.
 

--- a/lib/error-boundary.js
+++ b/lib/error-boundary.js
@@ -13,7 +13,7 @@ import {ResourcesConfig} from './config';
  * using the `setConfig` function in your config file:
  *
  * ```jsx
- * import {setConfig} from 'with-resources/config';
+ * import {setConfig} from 'resourcerer/config';
  *
  * setConfig({errorBoundaryChild: <MyErroredComponent />});
  * ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,7 +115,7 @@ const resourceState = (Component) =>
  *        fetched and cached
  *   * ...any other option that can be passed directly to the `request` function
  */
-const withResources = (getResources) =>
+export const withResources = (getResources) =>
   (Component) => {
     @resourceState
     @schmackboneMixin
@@ -651,5 +651,3 @@ function shouldBypassFetch(props, [name, {modelKey}]) {
 function not(fn) {
   return (...args) => !fn(...args);
 }
-
-export default withResources;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "with-resources",
+  "name": "resourcerer",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "with-resources",
+  "name": "resourcerer",
   "version": "0.1.0",
-  "repository": "github.com/SiftScience/with-resources",
+  "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [
     "declarative data-fetching framework",

--- a/test/with-resources.jsx
+++ b/test/with-resources.jsx
@@ -1,16 +1,17 @@
 import * as Request from '../lib/request';
 
+import {
+  EMPTY_COLLECTION,
+  EMPTY_MODEL,
+  getCacheKey,
+  withResources
+} from '../lib/index';
 import {hasErrored, hasLoaded, isLoading, noOp} from '../lib/utils';
 import {ModelMap, ResourceKeys, ResourcesConfig} from '../lib/config';
 import {
   scryRenderedComponentsWithType,
   scryRenderedDOMComponentsWithClass
 } from 'react-dom/test-utils';
-import withResources, {
-  EMPTY_COLLECTION,
-  EMPTY_MODEL,
-  getCacheKey
-} from '../lib/index';
 
 import ErrorBoundary from '../lib/error-boundary';
 import {LoadingStates} from '../lib/constants';


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
Conflict with existing `with-resources` npm package

## Description of Proposed Changes:  
  -  renames to `resourcerer` and edits all docs
  -  changes `withResources` HOC to a named export instead of the library's default export
  -  
