### PR TITLE
specify files to include in tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "backbone",
     "react"
   ],
+  "files": ["*.js", "*.md"],
   "main": "index.js",
   "scripts": {
     "checks": "npm test && npm run lint",


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
When publishing, only the transpiled `index.js` is included in the published tarball

## Description of Proposed Changes:  
  - includes `files` property in package.json that is a glob pattern for any top level transpiled javascript  
