### PR TITLE
fn component support

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,11 +633,49 @@ ResourcesConfig.set(configObj);
     
     * ...can this be turned into a React Hook?
     
-        I bet it can. React Hooks are exciting! However, they're also brand new, and the React team is still not recommending using them on production sites. As we are more concerned with stability and production-readiness in this package, `withResources` is a good-ol' higher-order component that wraps an 'old-school' React class component (it uses refs and thus wrapping function components will not work). But! The good news is that this library has been used at [Sift](https://sift.com) to power its [console](https://console.sift.com) for two years now, and so for us, it is tried and true (we'll see if it is tried and true for others!).
+        I bet it can. React Hooks are exciting! However, they're also brand new, and the React team is still not recommending using them on production sites. As we are more concerned with stability and production-readiness in this package, `withResources` is a good-ol' 'old-school' higher-order component that wraps a React class or functional component. But! The good news is that this library has been used at [Sift](https://sift.com) to power its [console](https://console.sift.com) for two years now, and so for us, it is tried and true (we'll see if it is tried and true for others!).
         
 * Can the `withResources` HOC be used with both function components and class components?
 
-    No (see previous answer above). Because it uses refs, it must wrap a React class component.
+    Yes! The docs don't show it, but this is totally valid:
+    
+    ```jsx
+    const UserTodos = (props) => (
+      <div className='MyClassWithTodosAndUsers'>
+        {props.isLoading ? <Loader /> : null}
+          
+        {props.hasLoaded ? (
+          <ul>
+            {props.userTodosCollection.map((todoModel) => (
+              <li key={todoModel.id}>
+                {todoModel.get('name')}
+              </li>
+            )}
+          </ul>
+        ) : null}
+          
+        {props.hasErrored ? <ErrorMessage /> : null}
+      </div>
+    );
+    
+    export withResources((props, ResourceKeys) => {
+      const now = Date.now();
+      
+      return {
+        [ResourceKeys.USER_TODOS]: {
+          data: {
+            limit: 20,
+            end_time: now,
+            start_time: now - props.timeRange,
+            sort_field: props.sortField
+          },
+          options: {userId: props.userId}
+        }
+      };
+    })(UserTodos)
+    ```
+    
+    There is one caveat, though&mdash;function components should not be wrapped in `React.memo` if you intend to listen on a resource via the `listen: true` option.
 
 * Can `resourcerer` do anything other than `GET` requests?
 

--- a/TESTING_COMPONENTS.md
+++ b/TESTING_COMPONENTS.md
@@ -10,14 +10,11 @@ When writing tests for components that use the `withResources` HOC, we want to b
       userId: 'noah'
     },
     
-    renderUserTodosList = (props={}, ref='dataChild') => {
-      var component = ReactDOM.render(
-        <UserTodosList {...defaultProps()} {...props} />,
-        document.body
-      );
-      
-      return ref && component[ref] || component;
-    };
+    renderUserTodosList = (props={}) => ReactDOM.render(
+      <UserTodosList {...defaultProps()} {...props} />,
+      document.body
+    );
+
         
     it('runs a test', () => {
       // both resources are passed as props, so no fetching takes place, and the component
@@ -26,31 +23,56 @@ When writing tests for components that use the `withResources` HOC, we want to b
     });
 ```
 
-One thing you may have noticed is the `ref` argument to the function. The HOC attaches a couple different refs to its children so that they can be accessed, if necessary. The only time it usually ever is necessary is during testing, where we may want to invoke an instance method on our component. So we usually bake it into our helper method when we need to. There are two refs of interest with the `withResources` HOC:
+### Access to HOC-wrapped Components
 
+In the last example, `userTodosList` is a reference to an instance of the fully-wrapped component class&mdash;not an instance of the class itself. To get references to the child components within our HOC, `resourcerer` exposes a few helper methods. There are generally two components of interest:
 
-- `dataCarrier` - the HOC wrapper component (useful to test changes in loading statuses for a component)
-- `dataChild` - the wrapped component (ie, the `UserTodosList` class instance) 
+- `DataCarrier` - the HOC wrapper component (useful to test changes in loading statuses for a component)
+- `DataChild` - the wrapped component (ie, the `UserTodosList` class instance)
 
+```jsx
+import {findDataCarrier, findDataChild, getRenderedResourceComponents} from 'resourcerer/test-utils';
 
-## Testing Loading/Error states and Resource Requests
+// ...
+    it('runs a test', () => {
+      // this actually a reference to the HOC-wrapped component instance
+      var resources = renderUserTodosList(),
+          // this is a reference to the component that does the data fetching, keeps loading states
+          // as state, and passes in models from the ModelCache to its child (user-defined component)
+          dataCarrier = findDataCarrier(resources),
+          // this is a reference to the unwrapped user-defined component class instance
+          dataChild = findDataChild(resources);
+          
+      // equivalently, you can use the `getRenderedResourceComponents` method to get all in one fell swoop:
+      ({dataCarrier, dataChild, resources} = getRenderedResourceComponents(renderUserTodosList()));
+      
+      console.log(resources.props.userTodosLoadingState); // undefined
+      console.log(dataCarrier.props.userTodosLoadingState); // undefined
+      console.log(dataCarrier.state.userTodosLoadingState); // 'loaded'
+      console.log(dataChild.props.userTodosLoadingState); // 'loaded'
+    });
 
-There are a few testing situations that are admittedly pretty clunky with `withResources`, and it’s largely due to lack of HOC-related access. So let’s walk through an example:
+```
 
-
-#### Testing Loading/Error States
+### Testing Loading/Error States
 
 This problem arises when we’ve stubbed out `withResources` with the resources it expects but have no way of easily controlling how the HOC passes down critical loading states (`hasLoaded`/`isLoading`/`hasErrored`). We can pass down individual loading states, ie `renderUserTodosSection({usersLoadingState: LoadingStates.ERROR})`, and that will help for noncritical loading UIs in the console, but it won’t have any effect on the critical loading props. (Side note: this is because `withResources` looks at its own state for those properties, and those don’t get overridden by props passed in.) Yet we often want to ensure that we get the correct error state is displayed when a component’s loading has errored, or that we show a loader when the component is loading.
     
 In order to test these, we need to change the state itself, and we can do that by adding a reference to our wrapping component, ie in a `beforeEach` hook or similar:
 
 ```js
+import {findDataCarrier, findDataChild, getRenderedResourceComponents} from 'resourcerer/test-utils';
+import {scryRenderedComponentsWithType} from 'react-dom/test-utils';
+
+// ...
     beforeEach(() => {
       resources = renderLoginsSection();
       // wrapping resources component that holds loading states
-      dataCarrier = resources.dataCarrier;
+      dataCarrier = findDataCarrier(resources)
       // wrapped component
-      userTodosList = resources.dataChild;
+      userTodosList = findDataChild(resources);
+      // equivalently:
+      // ({dataCarrier, dataChild: userTodosList, resources} = getRenderedResourceComponents(renderLoginsSection()));
     });
     
     // now, we can set state directly on our resources instance

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,8 +45,6 @@ const resourceState = (Component) =>
     render() {
       return (
         <Component
-          ref={(dataCarrier) => this.dataCarrier = dataCarrier}
-          attachDataChildRef={(dataChild) => this.dataChild = dataChild}
           {...this.props}
           // spread url params and merge with state. url should take priority
           // over passed props (like defaultProps), but state should take
@@ -438,11 +436,10 @@ export const withResources = (getResources) =>
         return (
           <ErrorBoundary>
             <Component
-              ref={(dataChild) => {
-                this.props.attachDataChildRef(dataChild);
+              {...(Component.prototype || {}).isReactComponent ? {
                 // allows for schmackboneMixin to call forceUpdate in this context
-                this.schmackboneContext = dataChild;
-              }}
+                ref: (dataChild) => this.schmackboneContext = dataChild
+              } : {}}
               // here we pass down our models
               {...resources.reduce((models, [name, config]) => ({
                 ...models,

--- a/package.json
+++ b/package.json
@@ -8,12 +8,15 @@
     "backbone",
     "react"
   ],
-  "files": ["*.js", "*.md"],
+  "files": [
+    "*.js",
+    "*.md"
+  ],
   "main": "index.js",
   "scripts": {
     "checks": "npm test && npm run lint",
     "lint": "eslint lib/*.js* test/*.js*",
-    "prepublishOnly": "babel lib -d ./",
+    "prepublishOnly": "babel lib -d ./ && babel test/test-utils.js -o ./test-utils.js",
     "test": "NODE_ENV=test && karma start"
   },
   "author": "",

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -29,3 +29,83 @@ export function waitsFor(condition, time=3000, name='something to happen') {
     }, 0);
   });
 }
+
+/**
+ * Returns reference the wrapped DataCarrier instance, which is in charge of
+ * keeping loading states as state and passing down our models from the model
+ * cache into the data child.
+ *
+ * @param {object} tree - the top node returned from a withResources declaration
+ * @return {object} the wrapped DataCarrier instance
+ */
+export function findDataCarrier(tree) {
+  wrapperCheck(tree);
+
+  return findChildAtDepth(tree, 1);
+}
+
+/**
+ * Returns reference the wrapped DataChild instance, which is the user-defined
+ * component that gets the @withResources decorator attached to it.
+ *
+ * @param {object} tree - the top node returned from a withResources declaration
+ * @return {object} the wrapped DataChild instance
+ */
+export function findDataChild(tree) {
+  wrapperCheck(tree);
+
+  return findChildAtDepth(tree, 3);
+}
+
+/**
+ * Return an object with reference all wrapped children returned within a
+ * withResources declaration instance.
+ *
+ * @param {object} tree - the top node returned from a withResources declaration
+ * @return {object} an object containing references to the parent resources
+ *   component, the data carrier, data child, and even the error boundary
+ *   component instances.
+ */
+export function getRenderedResourceComponents(tree) {
+  wrapperCheck(tree);
+
+  return {
+    resources: tree,
+    dataCarrier: findDataCarrier(tree),
+    dataChild: findDataChild(tree),
+    errorBoundary: findChildAtDepth(tree, 2)
+  };
+}
+
+/**
+ * In order for the wrapped-component convenience methods to work, the argument
+ * must be an instance of ResourceStateWrapper returned from a `withResources`
+ * declaration. This check throws an error if that is not the case.
+ *
+ * @param {object} tree - the top node for which to verify its type
+ */
+function wrapperCheck(tree) {
+  if (Object.getPrototypeOf(tree).constructor.name !== 'ResourceStateWrapper') {
+    throw new Error('Component must be of type returned by withResources function');
+  }
+}
+
+/**
+ * Core to our wrapped-component convenience methods, we simply walk down the
+ * React tree a specified depth, which we know to always be true for our
+ * wrapped components. This is all-the-easier because there are no siblings to
+ * crawl.
+ *
+ * @param {object} node - entry in the React render tree
+ * @param {number} depth - number of entries to crawl to get the child of interest
+ * @return {object} rendered instance of wrapped component
+ */
+function findChildAtDepth(node, depth=0) {
+  var i = 0;
+
+  while (i++ < depth) {
+    node = node.child || node._reactInternalFiber.child;
+  }
+
+  return node.stateNode;
+}


### PR DESCRIPTION
## Description of Proposed Changes:  
  - adds support for using `withResources` with stateless function components by removing refs used for testing, conditionally adding ref for schmackboneMixin listener
  - exposes new `test-utils` file for accessing DataCarrier and DataChild component instances
  - adds tests and documentation

