### PR TITLE
Prefetch hover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 node_modules
 *.js
 !lib/*.js
+!test/*.js

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ There's a lot there, so let's unpack that a bit. There's also a lot more that we
         1. [prefetches](#prefetches)
     1. [Caching Resources with ModelCache](#caching-resources-with-modelcache)
     1. [Declarative Cache Keys](#declarative-cache-keys)
+    1. [Prefetch on Hover](#prefetch-on-hover)
     1. [withLoadingOverlay](#withloadingoverlay)
 1. [Configuring resourcerer](#configuring-resourcerer)
 1. [FAQs](#faqs)
@@ -507,6 +508,8 @@ When the user clicks on a 'next' arrow that updates page state, the collection w
 1. Don't forget to add `from` to the [`cacheFields`](#declarative-cache-keys) list!
 1. The prefetched model does not get components registered to it; therefore, it is immediately scheduled for removal after the specified [cacheGracePeriod](#configuring). If the user clicks the next arrow, it then becomes the 'active' model and the `UserTodos` component will get registered to it, clearing the removal timer (see the next section).
 
+If you're looking to optimistically prefetch resources when a user hovers, say, over a link, see the [Prefetch on Hover](#prefetch-on-hover) section.
+
 
 ## Caching Resources with ModelCache
 
@@ -576,6 +579,36 @@ The generated cache key would be something like `userTodos_limit=50_$range=86400
 - the `userId` value is taken from the `options` hash
 - the `limit` and `sort_field` values are taken from the `data` hash
 - the `range` value is taken from a function that takes `start_millis`/`end_millis` from the `data` hash into account.
+
+
+## Prefetch on Hover
+
+You can use `resourcerer`'s executor function to optimistically prefetch resources when a user hovers over an element. For example, if a user hovers over a link to their TODOS page, you may want to get a head start on fetching their TODOS resource so that perceived loading time goes down or gets eliminated entirely. We can do this with the top-level `prefetch` function:
+
+```jsx
+import {prefetch} from 'resourcerer';
+
+// here's our executor function just as we pass to withResources
+const getTodos = (props, ResourceKeys) => {
+  const now = Date.now();
+      
+  return {
+    [ResourceKeys.USER_TODOS]: {
+      data: {
+        limit: props.limit,
+        end_time: now,
+        start_time: now - props.timeRange,
+        sort_field: props.sortField
+      },
+      options: {userId: props.userId}
+    }
+  };
+};
+
+// in your component, call the prefetch method with the executor and current props and
+// attach to an `onMouseEnter` prop
+<a href='/todos' onMouseEnter={prefetch(getTodos, this.props)}>TODOS</a>
+```
 
 ## withLoadingOverlay
 

--- a/README.md
+++ b/README.md
@@ -605,10 +605,13 @@ const getTodos = (props, ResourceKeys) => {
   };
 };
 
-// in your component, call the prefetch method with the executor and current props and
-// attach to an `onMouseEnter` prop
-<a href='/todos' onMouseEnter={prefetch(getTodos, this.props)}>TODOS</a>
+// in your component, call the prefetch method with the executor and an object that matches
+// what you expect the props to look like when the resources are requested without prefetch.
+// attach the result to an `onMouseEnter` prop
+<a href='/todos' onMouseEnter={prefetch(getTodos, expectedProps)}>TODOS</a>
 ```
+
+Note, as mentioned in the comment above, that `expectedProps` should take the form of props expected when the resource is actually needed. For example, maybe we're viewing a list of users, and so there is no `props.userId` in the component that uses `prefetch`. But for the user in the list with id `'noahgrant'`, we would pass it an `expectedProps` that includes `{userId: 'noahgrant'}` because we know that when we click on the link and navigate to that url, `props.userId` should be equal to `'noahgrant'`.
 
 ## withLoadingOverlay
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ import {hasErrored, hasLoaded, isLoading} from './utils';
 import {ModelMap, ResourceKeys, ResourcesConfig, UnfetchedResources} from './config';
 
 import _ from 'underscore';
+import _prefetch from './prefetch';
 import ErrorBoundary from './error-boundary';
 import {LoadingStates} from './constants';
 import ModelCache from './model-cache';
@@ -648,3 +649,5 @@ function shouldBypassFetch(props, [name, {modelKey}]) {
 function not(fn) {
   return (...args) => !fn(...args);
 }
+
+export const prefetch = _prefetch;

--- a/lib/prefetch.js
+++ b/lib/prefetch.js
@@ -1,0 +1,64 @@
+import {ModelMap, ResourceKeys} from './config';
+
+import _ from 'underscore';
+import {getCacheKey} from './index';
+import {noOp} from './utils';
+import request from './request';
+
+// prevents api request bursts based on quick swipes
+const PREFETCH_TIMEOUT = 50;
+
+/**
+ * Call this as with a resources config function and a component's props.
+ * The returned function should be applied to an onMouseEnter callback.
+ *
+ * @param {function} getResources - function that takes props as an argument
+ *   and should return a map of resources. Identical to those used in
+ *   `withResources` HOC
+ * @param {object} props - current component props
+ * @return {function} callback to be invoked onMouseEnter of appropriate DOM el
+ */
+export default (getResources, props) => {
+  var fetched,
+      resources = Object.entries(getResources(props, ResourceKeys) || {});
+
+  return (evt) => {
+    var {target} = evt,
+        prefetchTimeout;
+
+    if (target && !fetched) {
+      // set short timeout so that we can cancel if user 'doesn't intend'
+      // to click on the link
+      prefetchTimeout = window.setTimeout(() => {
+        resources.forEach(([name, config]) => {
+          // when this bug is fixed we can just destructure this:
+          // https://github.com/babel/babel/issues/7099
+          var {options, data} = config;
+
+          request(getCacheKey({modelKey: name, ...config}, props), ModelMap[name], {
+            fetchData: data,
+            options,
+            prefetch: true
+          // Prefetch is only opportunistic so if we error now,
+          // we'll retry and handle the error in withResources
+          }).catch(noOp);
+        });
+
+        fetched = true;
+      }, PREFETCH_TIMEOUT);
+
+      // if we leave the prefetch element before the timeout, don't prefetch
+      target.addEventListener('mouseleave', _.once(_onMouseLeave.bind(null, prefetchTimeout)));
+    }
+  };
+};
+
+/**
+ * If user swipes quickly over the DOM el of interest, cancel the timeout
+ * to avoid spamming the API.
+ *
+ * @param {number} timeout - timeout to clear so that prefetch doesn't happen
+ */
+function _onMouseLeave(timeout) {
+  window.clearTimeout(timeout);
+}

--- a/lib/prefetch.js
+++ b/lib/prefetch.js
@@ -15,12 +15,13 @@ const PREFETCH_TIMEOUT = 50;
  * @param {function} getResources - function that takes props as an argument
  *   and should return a map of resources. Identical to those used in
  *   `withResources` HOC
- * @param {object} props - current component props
+ * @param {object} expectedProps - props in the form expected when the resource
+ *   would be needed
  * @return {function} callback to be invoked onMouseEnter of appropriate DOM el
  */
-export default (getResources, props) => {
+export default (getResources, expectedProps) => {
   var fetched,
-      resources = Object.entries(getResources(props, ResourceKeys) || {});
+      resources = Object.entries(getResources(expectedProps, ResourceKeys) || {});
 
   return (evt) => {
     var {target} = evt,
@@ -31,11 +32,9 @@ export default (getResources, props) => {
       // to click on the link
       prefetchTimeout = window.setTimeout(() => {
         resources.forEach(([name, config]) => {
-          // when this bug is fixed we can just destructure this:
-          // https://github.com/babel/babel/issues/7099
           var {options, data} = config;
 
-          request(getCacheKey({modelKey: name, ...config}, props), ModelMap[name], {
+          request(getCacheKey({modelKey: name, ...config}, expectedProps), ModelMap[name], {
             fetchData: data,
             options,
             prefetch: true

--- a/test/prefetch.js
+++ b/test/prefetch.js
@@ -1,0 +1,78 @@
+import * as Request from '../lib/request';
+import {DecisionsCollection, UserModel} from './model-mocks';
+
+import prefetch from '../lib/prefetch';
+import ReactDOM from 'react-dom';
+import Schmackbone from 'schmackbone';
+
+const jasmineNode = document.createElement('div');
+const getResources = (props, {DECISIONS, USER}) => ({
+  [USER]: {
+    data: {home: props.home, source: props.source},
+    options: {userId: props.userId}
+  },
+  [DECISIONS]: {}
+});
+const props = {userId: 'noah', home: 'sf', source: 'hbase'};
+const dummyEvt = {target: jasmineNode};
+
+describe('prefetch', () => {
+  beforeEach(() => {
+    document.body.appendChild(jasmineNode);
+    spyOn(Request, 'default').and.callFake(() => Promise.resolve(new Schmackbone.Collection([])));
+
+    jasmine.clock().install();
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(jasmineNode);
+    jasmineNode.remove();
+    jasmine.clock().uninstall();
+  });
+
+  it('correctly turns the config object into cache key, data, and options', () => {
+    var oldFields = UserModel.cacheFields;
+
+    UserModel.cacheFields = ['userId', 'source'];
+
+    prefetch(getResources, props)(dummyEvt);
+    jasmine.clock().tick(100);
+
+    expect(Request.default.calls.argsFor(0)[0]).toEqual('usersource=hbase_userId=noah');
+    expect(Request.default.calls.argsFor(0)[1]).toEqual(UserModel);
+    expect(Request.default.calls.argsFor(0)[2]).toEqual({
+      options: {userId: 'noah'},
+      fetchData: {home: 'sf', source: 'hbase'},
+      prefetch: true
+    });
+
+    expect(Request.default.calls.argsFor(1)[0]).toEqual('decisions');
+    expect(Request.default.calls.argsFor(1)[1]).toEqual(DecisionsCollection);
+    expect(Request.default.calls.argsFor(1)[2]).toEqual({
+      fetchData: undefined,
+      options: undefined,
+      prefetch: true
+    });
+
+    UserModel.cacheFields = oldFields;
+  });
+
+  it('will fire if the user hovers over the element for longer than the timeout', () => {
+    var leaveEvt = new Event('mouseleave');
+
+    prefetch(getResources, props)(dummyEvt);
+    jasmine.clock().tick(50);
+    jasmineNode.dispatchEvent(leaveEvt);
+    expect(Request.default).toHaveBeenCalled();
+  });
+
+  it('will not fetch if the user leaves the element before the timeout', () => {
+    var leaveEvt = new Event('mouseleave');
+
+    prefetch(getResources, props)(dummyEvt);
+    jasmine.clock().tick(25);
+    jasmineNode.dispatchEvent(leaveEvt);
+    jasmine.clock().tick(25);
+    expect(Request.default).not.toHaveBeenCalled();
+  });
+});

--- a/test/prefetch.js
+++ b/test/prefetch.js
@@ -13,7 +13,7 @@ const getResources = (props, {DECISIONS, USER}) => ({
   },
   [DECISIONS]: {}
 });
-const props = {userId: 'noah', home: 'sf', source: 'hbase'};
+const expectedProps = {userId: 'noah', home: 'sf', source: 'hbase'};
 const dummyEvt = {target: jasmineNode};
 
 describe('prefetch', () => {
@@ -35,7 +35,7 @@ describe('prefetch', () => {
 
     UserModel.cacheFields = ['userId', 'source'];
 
-    prefetch(getResources, props)(dummyEvt);
+    prefetch(getResources, expectedProps)(dummyEvt);
     jasmine.clock().tick(100);
 
     expect(Request.default.calls.argsFor(0)[0]).toEqual('usersource=hbase_userId=noah');
@@ -60,7 +60,7 @@ describe('prefetch', () => {
   it('will fire if the user hovers over the element for longer than the timeout', () => {
     var leaveEvt = new Event('mouseleave');
 
-    prefetch(getResources, props)(dummyEvt);
+    prefetch(getResources, expectedProps)(dummyEvt);
     jasmine.clock().tick(50);
     jasmineNode.dispatchEvent(leaveEvt);
     expect(Request.default).toHaveBeenCalled();
@@ -69,7 +69,7 @@ describe('prefetch', () => {
   it('will not fetch if the user leaves the element before the timeout', () => {
     var leaveEvt = new Event('mouseleave');
 
-    prefetch(getResources, props)(dummyEvt);
+    prefetch(getResources, expectedProps)(dummyEvt);
     jasmine.clock().tick(25);
     jasmineNode.dispatchEvent(leaveEvt);
     jasmine.clock().tick(25);


### PR DESCRIPTION
## Description of Proposed Changes:  
  -  Adds `prefetch` as a top-level library export
  -  calling `prefetch` with an executor function and attaching to an `onMouseEnter` will optimistically fetch resources when a user hovers over the element
