### PR TITLE
add "direct" option to withLoadingOverlay

### DIFF
--- a/lib/with-loading-overlay.js
+++ b/lib/with-loading-overlay.js
@@ -12,9 +12,19 @@ const propTypes = {
   hasLoaded: PropTypes.bool
 };
 
-// if `noLoader` is true, only displays the translucent overlay without
-// the spinner on top of it.
-const defaultOptions = {noLoader: false};
+const defaultOptions = {
+  /**
+   * If true, does not add an additional component with falsy sCU after
+   * moving into a loading state. Allows for children to set their own
+   * sCU and use other lifecycle methods like cWRP on the client component.
+   */
+  direct: false,
+  /**
+   * If `noLoader` is true, only displays the translucent overlay without
+   * the spinner on top of it.
+   */
+  noLoader: false
+};
 
 const overlayStyle = {
   backgroundColor: 'rgba(255, 255, 255, 0.6)',
@@ -64,11 +74,15 @@ export default (options=defaultOptions) =>
               </div>
             ) : null}
             {this.state.hasInitiallyLoaded || this.props.hasErrored ? (
-              <NoUpdateIfLoading
-                Component={Component}
-                forwardRef={(child) => this.child = child}
-                {...this.props}
-              />
+              options.direct ? (
+                <Component ref={(child) => this.child = child} {...this.props} />
+              ) : (
+                <NoUpdateIfLoading
+                  Component={Component}
+                  forwardRef={(child) => this.child = child}
+                  {...this.props}
+                />
+              )
             ) : null}
           </div>
         );
@@ -82,7 +96,7 @@ export default (options=defaultOptions) =>
 
 // helper class to keep the wrapped component from updating when we move
 // into a loading state
-class NoUpdateIfLoading extends React.Component {
+export class NoUpdateIfLoading extends React.Component {
   shouldComponentUpdate(nextProps) {
     return !nextProps.isLoading;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/with-loading-overlay.jsx
+++ b/test/with-loading-overlay.jsx
@@ -1,21 +1,22 @@
+import withLoadingOverlay, {NoUpdateIfLoading} from '../lib/with-loading-overlay.js';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {ResourcesConfig} from '../lib/config';
 import {scryRenderedComponentsWithType} from 'react-dom/test-utils';
 import {waitsFor} from './test-utils';
-import withLoadingOverlay from '../lib/with-loading-overlay.js';
 
-const TestClass = class TestComponent extends React.Component {
+class TestComponent extends React.Component {
   render() {
     return <div />;
   }
-};
+}
 
 const {Loader} = ResourcesConfig;
 const jasmineNode = document.createElement('div');
 
 describe('WithLoadingOverlay', () => {
-  var Loady = withLoadingOverlay()(TestClass),
+  var Loady = withLoadingOverlay()(TestComponent),
       loady,
       loaders,
 
@@ -41,21 +42,34 @@ describe('WithLoadingOverlay', () => {
     expect(loaders[0].props.overlay).toBe(true);
   });
 
-  it('renders the wrapped component only after \'hasLoaded\' has been true once', (done) => {
+  it('renders the wrapped component only after \'hasLoaded\' has been true once', async(done) => {
     loady = renderLoady();
-    expect(scryRenderedComponentsWithType(loady, TestClass).length).toEqual(0);
+    expect(scryRenderedComponentsWithType(loady, TestComponent).length).toEqual(0);
     loady = renderLoady({hasLoaded: true});
 
-    return waitsFor(() => loady.state.hasInitiallyLoaded).then(() => {
-      expect(scryRenderedComponentsWithType(loady, TestClass).length).toEqual(1);
-      done();
-    });
+    await waitsFor(() => loady.state.hasInitiallyLoaded);
+
+    expect(scryRenderedComponentsWithType(loady, TestComponent).length).toEqual(1);
+    done();
   });
 
   it('does not show the spinner if passed a \'noLoader\' option', () => {
-    loady = renderLoady({isLoading: true}, withLoadingOverlay({noLoader: true})(TestClass));
+    loady = renderLoady({isLoading: true}, withLoadingOverlay({noLoader: true})(TestComponent));
     loaders = scryRenderedComponentsWithType(loady, Loader);
 
     expect(loaders.length).toEqual(0);
+  });
+
+  it('does not include its own intermediary component if passed a \'direct\' option', () => {
+    // pass hasErrored just as an easy way to render its children
+    loady = renderLoady({hasErrored: true});
+    expect(scryRenderedComponentsWithType(loady, NoUpdateIfLoading).length).toEqual(1);
+    expect(scryRenderedComponentsWithType(loady, NoUpdateIfLoading)[0].props.Component)
+        .toEqual(TestComponent);
+    ReactDOM.unmountComponentAtNode(jasmineNode);
+
+    loady = renderLoady({hasErrored: true}, withLoadingOverlay({direct: true})(TestComponent));
+    expect(scryRenderedComponentsWithType(loady, NoUpdateIfLoading).length).toEqual(0);
+    expect(loady.child instanceof TestComponent).toBe(true);
   });
 });


### PR DESCRIPTION
## Description of Proposed Changes:  
  -  Provides a `{direct: true}` option to `withLoadingOverlay to opt out of the auto-intermediary component that returns false from `shouldComponentUpdate` when moving into a loading state

