### PR TITLE
always return statuses for useResources hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,8 @@ Note a couple critical differences:
 
 1. The hook does not accept a [`{listen: true}`](#listen) option like the HOC does because it listens to changes on all resources by default. A similar update will be made in the future to `withResources`.
 
+1. Likewise, the hook does not accept a [`{status: true}`](#status) option like the HOC does because it returns all statuses by default.
+
 ## Caching Resources with ModelCache
 
 `resourcerer` handles resource storage and caching, so that when multiple components request the same resource with the same parameters or the same body, they receive the same model in response. If multiple components request a resource still in-flight, only a single request is made, and each component awaits the return of the same resource. Fetched resources are stored by `withResources` in the `ModelCache`. Under most circumstances, you won’t need to interact with directly; but it’s still worth knowing a little bit about what it does.
@@ -860,7 +862,7 @@ ResourcesConfig.set(configObj);
 
 * How big is the `resourcerer` package?  
 
-    4kB gzipped.
+    5kB gzipped (excluding its Schmackbone, Underscore, and qs dependencies, which are an additional 17kB gzipped).
 
 * Semver?  
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -820,7 +820,7 @@ function loaderReducer(
   {loadingStates, requestStatuses, hasInitiallyLoaded},
   {type, payload={}}
 ) {
-  var {name, config={}, model={}, resources} = payload;
+  var {name, model={}, resources} = payload;
 
   switch (type) {
     case LoadingStates.ERROR:
@@ -829,10 +829,7 @@ function loaderReducer(
 
       return {
         loadingStates: nextLoadingStates,
-        requestStatuses: {
-          ...requestStatuses,
-          ...(config.status ? {[getResourceStatus(name)]: model.status} : {})
-        },
+        requestStatuses: {...requestStatuses, [getResourceStatus(name)]: model.status},
         hasInitiallyLoaded: hasInitiallyLoaded || (type === LoadingStates.LOADED &&
           hasLoaded(getCriticalLoadingStates(nextLoadingStates, resources)) && !hasInitiallyLoaded)
       };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/use-resources.jsx
+++ b/test/use-resources.jsx
@@ -28,8 +28,7 @@ const getResources = (props) => ({
   [ResourceKeys.DECISIONS]: {
     ...(props.includeDeleted ? {data: {include_deleted: true}} : {}),
     listen: true,
-    measure,
-    status: props.status
+    measure
   },
   [ResourceKeys.NOTES]: {noncritical: true, dependsOn: ['noah']},
   [ResourceKeys.USER]: {
@@ -61,7 +60,6 @@ const getResources = (props) => ({
   ...props.customName ? {
     customDecisions: {
       modelKey: ResourceKeys.DECISIONS,
-      status: true,
       provides: {sift: () => 'science'}
     }
   } : {},
@@ -942,47 +940,45 @@ describe('useResources', () => {
     });
   });
 
-  describe('for a response with \'status\'', () => {
-    it('sets the status when resource loads', async(done) => {
-      dataChild = findDataChild(renderUseResources({status: true}));
-      expect(dataChild.props.decisionsLoadingState).toBe(LoadingStates.LOADING);
-      expect(dataChild.props.userLoadingState).toBe(LoadingStates.LOADING);
-      expect(dataChild.props.analystsLoadingState).toBe(LoadingStates.LOADING);
-      expect(dataChild.props.decisionsStatus).toEqual(undefined);
-      expect(dataChild.props.userStatus).toEqual(undefined);
-      expect(dataChild.props.analystsStatus).toEqual(undefined);
+  it('sets the status when resource loads', async(done) => {
+    dataChild = findDataChild(renderUseResources());
+    expect(dataChild.props.decisionsLoadingState).toBe(LoadingStates.LOADING);
+    expect(dataChild.props.userLoadingState).toBe(LoadingStates.LOADING);
+    expect(dataChild.props.analystsLoadingState).toBe(LoadingStates.LOADING);
+    expect(dataChild.props.decisionsStatus).toEqual(undefined);
+    expect(dataChild.props.userStatus).toEqual(undefined);
+    expect(dataChild.props.analystsStatus).toEqual(undefined);
 
-      await waitsFor(() => dataChild.props.hasLoaded);
+    await waitsFor(() => dataChild.props.hasLoaded);
 
-      expect(dataChild.props.decisionsLoadingState).toBe(LoadingStates.LOADED);
-      expect(dataChild.props.userLoadingState).toBe(LoadingStates.LOADED);
-      expect(dataChild.props.analystsLoadingState).toBe(LoadingStates.LOADED);
-      expect(dataChild.props.decisionsStatus).toBe(200);
-      expect(dataChild.props.userStatus).toEqual(undefined);
-      expect(dataChild.props.analystsStatus).toEqual(undefined);
-      done();
-    });
+    expect(dataChild.props.decisionsLoadingState).toBe(LoadingStates.LOADED);
+    expect(dataChild.props.userLoadingState).toBe(LoadingStates.LOADED);
+    expect(dataChild.props.analystsLoadingState).toBe(LoadingStates.LOADED);
+    expect(dataChild.props.decisionsStatus).toBe(200);
+    expect(dataChild.props.userStatus).toEqual(200);
+    expect(dataChild.props.analystsStatus).toEqual(200);
+    done();
+  });
 
-    it('sets the status when resource errors', async(done) => {
-      shouldResourcesError = true;
-      dataChild = findDataChild(renderUseResources({status: true}));
-      expect(dataChild.props.decisionsLoadingState).toBe(LoadingStates.LOADING);
-      expect(dataChild.props.userLoadingState).toBe(LoadingStates.LOADING);
-      expect(dataChild.props.analystsLoadingState).toBe(LoadingStates.LOADING);
-      expect(dataChild.props.decisionsStatus).toEqual(undefined);
-      expect(dataChild.props.userStatus).toEqual(undefined);
-      expect(dataChild.props.analystsStatus).toEqual(undefined);
+  it('sets the status when resource errors', async(done) => {
+    shouldResourcesError = true;
+    dataChild = findDataChild(renderUseResources());
+    expect(dataChild.props.decisionsLoadingState).toBe(LoadingStates.LOADING);
+    expect(dataChild.props.userLoadingState).toBe(LoadingStates.LOADING);
+    expect(dataChild.props.analystsLoadingState).toBe(LoadingStates.LOADING);
+    expect(dataChild.props.decisionsStatus).toEqual(undefined);
+    expect(dataChild.props.userStatus).toEqual(undefined);
+    expect(dataChild.props.analystsStatus).toEqual(undefined);
 
-      await waitsFor(() => dataChild.props.hasErrored && !dataChild.props.isLoading);
+    await waitsFor(() => dataChild.props.hasErrored && !dataChild.props.isLoading);
 
-      expect(dataChild.props.decisionsLoadingState).toBe(LoadingStates.ERROR);
-      expect(dataChild.props.userLoadingState).toBe(LoadingStates.ERROR);
-      expect(dataChild.props.analystsLoadingState).toBe(LoadingStates.ERROR);
-      expect(dataChild.props.decisionsStatus).toBe(404);
-      expect(dataChild.props.userStatus).toEqual(undefined);
-      expect(dataChild.props.analystsStatus).toEqual(undefined);
-      done();
-    });
+    expect(dataChild.props.decisionsLoadingState).toBe(LoadingStates.ERROR);
+    expect(dataChild.props.userLoadingState).toBe(LoadingStates.ERROR);
+    expect(dataChild.props.analystsLoadingState).toBe(LoadingStates.ERROR);
+    expect(dataChild.props.decisionsStatus).toBe(404);
+    expect(dataChild.props.userStatus).toEqual(404);
+    expect(dataChild.props.analystsStatus).toEqual(404);
+    done();
   });
 
   it('sets an error state when a resource errors, but does not log', async(done) => {


### PR DESCRIPTION
## Description of Proposed Changes:  
  -  Eliminates need for adding a `status: true` option with `useResources`
  - bumps to v0.5.1

