### PR TITLE
set models before loading state, bump version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -398,20 +398,26 @@ export const useResources = (getResources, props) => {
         isCurrentResource: ([name, config], cacheKey) => isMountedRef.current && !config.prefetch &&
           cacheKey === findCacheKey([name, config], getResources, currentPropsRef.current),
         setResourceState,
-        onRequestSuccess: (model, [name, config]) => loaderDispatch({
-          type: LoadingStates.LOADED,
-          payload: {name, config, model, resources}
-        }),
+        onRequestSuccess: (model, [name, config]) => {
+          // TODO: in my experience i've found that setting models and setting
+          // loading states are not batched together!! i have no idea why. so
+          // for now setting models first to ensure that when state is loaded, the
+          // correct resource is available
+          if (resources.filter(withoutPrefetch).length) {
+            setModels(modelAggregator(resources.filter(withoutPrefetch), props));
+          }
+
+          loaderDispatch({
+            type: LoadingStates.LOADED,
+            payload: {name, config, model, resources}
+          });
+        },
         onRequestFailure: (model, [name, config]) => loaderDispatch({
           type: LoadingStates.ERROR,
           payload: {name, config, model}
         })
       }).then(() => {
         if (isMountedRef.current) {
-          if (resources.filter(withoutPrefetch).length) {
-            setModels(modelAggregator(resources.filter(withoutPrefetch), props));
-          }
-
           // attaches listeners on all resources
           resources.map(([, config]) => getModelFromCache(config, props))
               .filter(Boolean)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
- Fixes issue in `useResources` where `hasLoaded` is true but the related model is the empty model or a state model, since they are kept in state

## Description of Proposed Changes:  
  -  sets our models after successful fetch only (since they're only added to the cache on success, anyway) and before loading states are set.
  - will need to figure out why these were calling render synchronously
  
