### PR TITLE
force batch loaded and model state updates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ import _ from 'underscore';
 import ErrorBoundary from './error-boundary';
 import {LoadingStates} from './constants';
 import ModelCache from './model-cache';
+import ReactDOM from 'react-dom';
 import request from './request';
 import Schmackbone from 'schmackbone';
 import schmackboneMixin from './schmackbone-mixin';
@@ -399,17 +400,18 @@ export const useResources = (getResources, props) => {
           cacheKey === findCacheKey([name, config], getResources, currentPropsRef.current),
         setResourceState,
         onRequestSuccess: (model, [name, config]) => {
-          // TODO: in my experience i've found that setting models and setting
-          // loading states are not batched together!! i have no idea why. so
-          // for now setting models first to ensure that when state is loaded, the
-          // correct resource is available
-          if (resources.filter(withoutPrefetch).length) {
-            setModels(modelAggregator(resources.filter(withoutPrefetch), props));
-          }
+          // to batch these state updates into one, per this comment:
+          // https://stackoverflow.com/questions/48563650/
+          // does-react-keep-the-order-for-state-updates/48610973#48610973
+          ReactDOM.unstable_batchedUpdates(() => {
+            if (resources.filter(withoutPrefetch).length) {
+              setModels(modelAggregator(resources.filter(withoutPrefetch), props));
+            }
 
-          loaderDispatch({
-            type: LoadingStates.LOADED,
-            payload: {name, config, model, resources}
+            loaderDispatch({
+              type: LoadingStates.LOADED,
+              payload: {name, config, model, resources}
+            });
           });
         },
         onRequestFailure: (model, [name, config]) => loaderDispatch({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
per [this detailed comment](https://stackoverflow.com/questions/48563650/does-react-keep-the-order-for-state-updates/48610973#48610973) about how state updates are only batched for event handlers and _NOT_ for things like resolved promise handlers. for now—until concurrent mode.


## Description of Proposed Changes:  
  -  uses `ReactDOM.unstable_batchedUpdates`

