### PR TITLE
fix prefetch parameters

### DIFF
--- a/lib/prefetch.js
+++ b/lib/prefetch.js
@@ -32,11 +32,8 @@ export default (getResources, expectedProps={}) => {
       // to click on the link
       prefetchTimeout = window.setTimeout(() => {
         resources.forEach(([name, config]) => {
-          var {options, data} = config;
-
           request(getCacheKey({modelKey: name, ...config}, expectedProps), ModelMap[name], {
-            fetchData: data,
-            options,
+            ...config,
             prefetch: true
           // Prefetch is only opportunistic so if we error now,
           // we'll retry and handle the error in withResources

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/prefetch.js
+++ b/test/prefetch.js
@@ -42,17 +42,13 @@ describe('prefetch', () => {
     expect(Request.default.calls.argsFor(0)[1]).toEqual(UserModel);
     expect(Request.default.calls.argsFor(0)[2]).toEqual({
       options: {userId: 'noah'},
-      fetchData: {home: 'sf', source: 'hbase'},
+      data: {home: 'sf', source: 'hbase'},
       prefetch: true
     });
 
     expect(Request.default.calls.argsFor(1)[0]).toEqual('decisions');
     expect(Request.default.calls.argsFor(1)[1]).toEqual(DecisionsCollection);
-    expect(Request.default.calls.argsFor(1)[2]).toEqual({
-      fetchData: undefined,
-      options: undefined,
-      prefetch: true
-    });
+    expect(Request.default.calls.argsFor(1)[2]).toEqual({prefetch: true});
 
     UserModel.cacheFields = oldFields;
   });


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
- prefetch module was not passing along `attributes` or `data` being passed to it

## Description of Proposed Changes:  
  -  pass along entire `config` object calculated in the prefetch
  -  bump patch version
