### PR TITLE
export binding shortcut not working

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ import {ModelMap, ResourceKeys, ResourcesConfig, UnfetchedResources} from './con
 import React, {useEffect, useReducer, useRef, useState} from 'react';
 
 import _ from 'underscore';
+import _prefetch from './prefetch';
 import ErrorBoundary from './error-boundary';
 import {LoadingStates} from './constants';
 import ModelCache from './model-cache';
@@ -970,4 +971,4 @@ function fetchResources(resources, props, {
   );
 }
 
-export {prefetch} from './prefetch';
+export const prefetch = _prefetch;


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
- Issue where `export` shorthand syntax for the prefetch module was not working

