### PR TITLE
reorder hook props and give loading overlay a className

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -447,6 +447,13 @@ export const useResources = (getResources, props) => {
   currentPropsRef.current = props;
 
   return {
+    // spread url params and merge with state. url should take priority
+    // over passed props (like defaultProps), but state should take
+    // precedence over all
+    ...props,
+    ...props[ResourcesConfig.queryParamsPropName] || {},
+    ..._resourceState,
+
     setResourceState,
 
     ...models,
@@ -454,13 +461,6 @@ export const useResources = (getResources, props) => {
     // here we include our model loading states, useful for noncritical resources
     ...loadingStates,
     ...requestStatuses,
-
-    // spread url params and merge with state. url should take priority
-    // over passed props (like defaultProps), but state should take
-    // precedence over all
-    ...props,
-    ...props[ResourcesConfig.queryParamsPropName] || {},
-    ..._resourceState,
 
     // these props represent our critical resource loading states
     hasErrored: hasErrored(criticalLoadingStates),

--- a/lib/loading-overlay.js
+++ b/lib/loading-overlay.js
@@ -69,7 +69,7 @@ export const withLoadingOverlay = (options=defaultOptions) =>
         const {Loader} = ResourcesConfig;
 
         return (
-          <div style={{position: 'relative'}}>
+          <div className='LoadingOverlay' style={{position: 'relative'}}>
             {this.props.isLoading ? (
               <div style={overlayStyle}>
                 {!options.noLoader ? <Loader overlay /> : null}
@@ -143,7 +143,7 @@ export function LoadingOverlay(props) {
 
   return (
     <ErrorBoundary>
-      <div style={{position: 'relative'}}>
+      <div className='LoadingOverlay' style={{position: 'relative'}}>
         {props.isLoading ? (
           <div style={overlayStyle}>
             {!props.noLoader ? <Loader overlay /> : null}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

Currently, if you pass `{...props}` from a parent component that uses the `withResources` HOC, some of its props will override the return values from the `useResources` hook. This includes `setResourceState`, among others.

## Description of Proposed Changes:  
  -  Makes LoadingOverlay components targetable by adding a `className`
  -  spreads hook props before hook-specific attributes
  
