### PR TITLE
let props override models

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -447,6 +447,8 @@ export const useResources = (getResources, props) => {
   currentPropsRef.current = props;
 
   return {
+    ...models,
+
     // spread url params and merge with state. url should take priority
     // over passed props (like defaultProps), but state should take
     // precedence over all
@@ -455,8 +457,6 @@ export const useResources = (getResources, props) => {
     ..._resourceState,
 
     setResourceState,
-
-    ...models,
 
     // here we include our model loading states, useful for noncritical resources
     ...loadingStates,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
Issue where passing models as props is no longer taking precedence

## Description of Proposed Changes:  
  -  Reverts a portion of #49 to allow props to override models. Without this models can't be passed in to tell our components to bypass a fetch, as we always do [in testing](https://github.com/SiftScience/resourcerer/blob/master/TESTING_COMPONENTS.md#testing-components-that-use-withresources) and also sometimes do in our applications.
