### PR TITLE
correctly initialize hasInitiallyLoaded

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -127,15 +127,19 @@ export const withResources = (getResources) =>
         super();
 
         let resources = this._generateResources(props);
+        let initialLoadingStates = buildResourcesLoadingState(
+          resources.filter(withoutPrefetch),
+          props
+        );
 
         // set initial loading state for our resources
         this.state = {
-          ...buildResourcesLoadingState(resources.filter(withoutPrefetch), props),
+          ...initialLoadingStates,
           /**
            * Whether our critical resources have been loaded a first time. Useful for showing
            * reflecting a different UI for subsequent requests
            */
-          hasInitiallyLoaded: false
+          hasInitiallyLoaded: hasLoaded(getCriticalLoadingStates(initialLoadingStates, resources))
         };
       }
 
@@ -324,13 +328,15 @@ export const useResources = (getResources, props) => {
       props = {...props, ..._resourceState},
       resources = generateResources(getResources, props),
 
+      initialLoadingStates = buildResourcesLoadingState(resources.filter(withoutPrefetch), props),
+
       // set initial loading states and create loaderDispatch for maintaining them
       [{loadingStates, requestStatuses, hasInitiallyLoaded}, loaderDispatch] = useReducer(
         loaderReducer,
         {
-          loadingStates: buildResourcesLoadingState(resources.filter(withoutPrefetch), props),
+          loadingStates: initialLoadingStates,
           requestStatuses: {},
-          hasInitiallyLoaded: false
+          hasInitiallyLoaded: hasLoaded(getCriticalLoadingStates(initialLoadingStates, resources))
         }
       ),
       criticalLoadingStates = getCriticalLoadingStates(loadingStates, resources),

--- a/test/use-resources.jsx
+++ b/test/use-resources.jsx
@@ -198,6 +198,23 @@ describe('useResources', () => {
     done();
   });
 
+  it('\'hasInitiallyLoaded\' is initially true if all critical models are passed', () => {
+    dataChild = findDataChild(renderUseResources({
+      decisionsCollection: new Schmackbone.Collection(),
+      userModel: new Schmackbone.Model()
+    }));
+
+    expect(dataChild.props.hasInitiallyLoaded).toBe(true);
+    unmountAndClearModelCache();
+
+    dataChild = findDataChild(renderUseResources({
+      // analystsCollection is noncritical
+      analystsCollection: new Schmackbone.Collection(),
+      userModel: new Schmackbone.Model()
+    }));
+    expect(dataChild.props.hasInitiallyLoaded).toBe(false);
+  });
+
   it('resource keys get turned into props of the same name, with \'Model\' or ' +
       '\'Collection\' appended as appropriate', async(done) => {
     dataChild = findDataChild(renderUseResources());

--- a/test/with-resources.jsx
+++ b/test/with-resources.jsx
@@ -227,6 +227,23 @@ describe('withResources', () => {
     done();
   });
 
+  it('\'hasInitiallyLoaded\' is initially true if all critical models are passed', () => {
+    dataChild = findDataChild(renderWithResources({
+      decisionsCollection: new Schmackbone.Collection(),
+      userModel: new Schmackbone.Model()
+    }));
+
+    expect(dataChild.props.hasInitiallyLoaded).toBe(true);
+    unmountAndClearModelCache();
+
+    dataChild = findDataChild(renderWithResources({
+      // analystsCollection is noncritical
+      analystsCollection: new Schmackbone.Collection(),
+      userModel: new Schmackbone.Model()
+    }));
+    expect(dataChild.props.hasInitiallyLoaded).toBe(false);
+  });
+
   it('resource keys get turned into props of the same name, with \'Model\' or ' +
       '\'Collection\' appended as appropriate', async(done) => {
     dataChild = findDataChild(renderWithResources());


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
Current in both the HOC and the hook, `hasInitiallyLoaded` state is always initialized to `false`. However, if all critical models are passed as props (which is most often the case in testing but also has use-cases in an application), this should be initialized to `true`.

It's likely in its current form that the state never actually gets set to `true` because no requests are returned, updating their loading states and calling `cDU` or `useEffect`.

## Description of Proposed Changes:  
  -  make `hasInitiallyLoaded` state initially dependent on the loading state of critical resources, which, when passed in, are subject to `shouldBypassFetch` and set to `LOADED`

