### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ The Loader instance will get an `overlay: true` prop if it is rendered by `withL
 
 ### Usage with the `useResources` hook
 
-When using `useResources`, the `withLoadingOverlay` HOC won't work without breaking up your components; however, since models are held as state with the hook, a loading overlay helper component to keep older models rendered while new ones are requested is unnecessary. We can simply use `hasInitiallyLoaded`:
+When using `useResources`, the `withLoadingOverlay` HOC won't work without breaking up your components; however, since models are held as state, a loading overlay helper component is unnecessary to keep older models rendered while requesting new ones. We can simply use `hasInitiallyLoaded`:
 
 ```jsx
 import {useResources} from 'resourcerer';

--- a/TESTING_COMPONENTS.md
+++ b/TESTING_COMPONENTS.md
@@ -94,3 +94,37 @@ import {scryRenderedComponentsWithType} from 'react-dom/test-utils';
       expect(userTodosList.props.hasLoaded).toBe(true);
     });
 ```
+
+## Testing Components that Use `useResources`
+
+When using the `useResources` hook, we are necessarily using React function components that have no backing instances (and thus whose return from `render` is `null`). Therefore, we can't assert any prop values on components and we can't navigate a DOM tree the way we can when using classes. However, we can simply mock out `useResources` itself to test functionality. Here's an example (using [jest](https://jestjs.io/)) for testing how a component that uses `useResources` looks under a loading state:
+
+```jsx
+import * as resourcerer from 'resourcerer';
+
+// ...
+it('shows a loader when in a loading state', () => {
+   jest.spyOn(resourcerer, 'useResources').mockImplementation((fn, props) => ({
+     ...props,
+     hasLoaded: false,
+     isLoading: true
+   ));
+
+   const {container} = render(<MyComponent />);
+   
+   expect(container.querySelector('.Loader')).toBeInTheDocument();
+});
+```
+
+This should solve most of your use cases; you can return any mocked info you want, such as a noncritical loading state. You can also mock out `setResourceState`:
+
+```jsx
+ var setResourceMock = jest.fn();
+ 
+ jest.spyOn(resourcerer, 'useResources').mockImplementation((fn, props) => ({
+   ...props,
+   setResourceState: setResourceMock
+ ));
+```
+
+Keep in mind that in this case the calls to `setResourceState` won't actually go through, and so state won't persist. 

--- a/lib/index.js
+++ b/lib/index.js
@@ -345,7 +345,7 @@ export const useResources = (getResources, props) => {
       // reading from the model cache with updated props, and so we'd _always_
       // show an empty model as a resource is being requested instead of
       // continuing to show the previous model. on the plus side, setting them
-      // as state means we won't need to sCU/memo the loading overlay
+      // as state means we won't need a loading overlay component to do this for us
       [models, setModels] = useState(modelAggregator(resources, props)),
 
       isMountedRef = useIsMounted(false),

--- a/lib/loading-overlay.js
+++ b/lib/loading-overlay.js
@@ -130,6 +130,9 @@ export class NoUpdateIfLoading extends React.Component {
  * Because useResources keeps its models as state instead of reading directly
  * from the cache, there is no need for a sCU-equivalent to keep the children
  * from updating when we go to a loading state.
+ *
+ * NOTE: THIS COMPONENT IS DEPRECATED AND WILL BE REMOVED IN A FUTURE RELEASE.
+ * OPT INSTEAD TO USE `HASINITIALLYLOADED` AS RETURNED FROM THE HOOK.
  */
 export function LoadingOverlay(props) {
   const {Loader} = ResourcesConfig;


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
- Deprecates `LoadingOverlay` and removes it from documentation in lieu of preferred approaches
- Adds hook testing advice to the testing docs

