### PR TITLE
Export models

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Additional features include:
 
 It employs a View-less, jQuery-less fork of Backbone called [Schmackbone](https://github.com/noahgrant/schmackbone) for Model/Collection semantics (as well as its [Events module](https://backbonejs.org/#Events)). Getting started is easy:
 
-1. Define a Schmackbone model in your application:
+1. Define a model in your application:
 
 ```js
 // js/models/todos-collection.js
-import Schmackbone from 'schmackbone';
+import {Collection} from 'resourcerer';
 
-export default class TodosCollection extends Schmackbone.Collection {
+export default class TodosCollection extends Collection {
   url() {
     return '/todos';
   }
@@ -260,15 +260,17 @@ And here's what our model might look like:
 
 ```js
 // js/models/user-model.js
-export default Schmackbone.Model.extend({
-  initialize(attributes, options={}) {
+export default class UserModel extends Model {
+  constructor(attributes, options={}) {
     this.userId = options.userId;
-  },
+  }
   
   url() {
     return `/users/${this.userId}`;
   }
-}, {cacheFields: ['userId']});
+  
+  static cacheFields = ['userId']
+}
 ```
 
 The `cacheFields` static property is important here, as we'll see in a second; it is a list of model properties that `resourcerer` will use to generate a cache key for the model. It will look for the `userId` property in the following places, in order:
@@ -448,7 +450,7 @@ would still fetch the todos resource, but the props passed to the `MyComponentWi
 
 ### options 
 
-[As referenced previously](#requesting-prop-driven-data), an `options` hash on a resource config will be passed directly as the second parameter to a model's `initialize` method. It will also be used in cache key generation if it has any fields specified in the model's static `cacheFields` property (See the [cache key section](#declarative-cache-keys) for more). Continuing with our User Todos example, let's add an `options` property:
+[As referenced previously](#requesting-prop-driven-data), an `options` hash on a resource config will be passed directly as the second parameter to a model's `constructor` method. It will also be used in cache key generation if it has any fields specified in the model's static `cacheFields` property (See the [cache key section](#declarative-cache-keys) for more). Continuing with our User Todos example, let's add an `options` property:
 
 ```js
   @withResources((props, ResourceKeys) => {
@@ -473,7 +475,7 @@ Here, the UserTodos collection will be instantiated with an options hash includi
 
 ### attributes
 
-Pass in an attributes hash to initialize a Schmackbone.Model instance with a body before initially fetching. This is passed directly to the model's [`initialize` method](https://backbonejs.org/#Model-constructor) along with the `options` property.
+Pass in an attributes hash to initialize a Model instance with a body before initially fetching. This is passed directly to the model's [`constructor` method](https://backbonejs.org/#Model-constructor) along with the `options` property.
 
 ### prefetches
 
@@ -635,23 +637,23 @@ Let's take a look at the USER_TODOS resource from above, where we want to reques
 And our corresponding model definition might look like this:
 
 ```js
-export const UserTodosCollection = Schmackbone.Collection.extend({
-  initialize(models, options={}) {
+export class UserTodosCollection extends Collection {
+  constructor(models, options={}) {
     this.userId = options.userId;
-  },
+  }
   
   url() {
     return `/users/${this.userId}/todos`;
   }
   // ...
-}, {
-  cacheFields: [
+  
+  static cacheFields = [
     'limit',
     'userId',
     'sort_field',
      ({end_millis, start_millis}) => ({range: end_millis - start_millis})
   ]
-});
+};
 ```
 
 We can see that `limit` and `sort_field` as specified in `cacheFields` are taken straight from the `data` object that Schmackbone transforms into url query parameters. `userId` is part of the `/users/{userId}/todos` path, so it can't be part of the `data` object, which is why it's stored as an instance property. But `resourcerer` will see its value within the `options` hash that is passed and use it for the cache key.  
@@ -878,11 +880,11 @@ ResourcesConfig.set(configObj);
   
       // any other mounted component in the application listening to this model or its collection
       // will get re-rendered with the updated name as soon as this is called
-      this.props.userTodoModel.save({name: 'Giving This Todo A New Name}, {
-        success: () => notify('Todo save succeeded!'),
-        error: () => notify('Todo save failed :/'),
-        complete: () => this.setState({isSaving: false})
-      });
+      this.props.userTodoModel.save({name: 'Giving This Todo A New Name})
+          .then(
+            () => notify('Todo save succeeded!'),
+            () => notify('Todo save failed :/')
+          ).then(() => this.setState({isSaving: false})
     }
     ```
 

--- a/README.md
+++ b/README.md
@@ -783,6 +783,7 @@ ResourcesConfig.set(configObj);
 
 * `log` (function): method invoked when an error is caught by the ErrorBoundary. Takes the caught error as an argument. Use this hook to send caught errors to your error monitoring system. Default noop.
 
+* `prefilter` (function): proxy for Schmackbone's [ajaxPrefilter](https://github.com/noahgrant/schmackbone#backboneajaxprefilter) method, which is a great place to add custom request headers (like auth headers) or do custom error response handling. See Schmackbone's documentation for more. Default noop.
 * `queryParamsPropName` (string): the name of the prop representing url query parameters that `withResources` will look for and flatten for its children. If your application already flattens query parameters, you can ignore this property. Otherwise, when a url search string of, for example, `?end_time=1558100000000&start_time=1555508000000` is turned into an object prop of `{end_time: 1558100000000, start_time: 1555508000000}`, `withResources`-wrapped components will see `props.end_time` and `props.start_time`, for ease of use in your executor function. Default `'urlParams'`.
 
 * `track` (function): method invoked when [`measure: true`](#measure) is passed in a resource's config. Use this hook to send the measured data to your application analytics tracker. Default noop. The method is invoked with two arguments:

--- a/README.md
+++ b/README.md
@@ -880,11 +880,11 @@ ResourcesConfig.set(configObj);
   
       // any other mounted component in the application listening to this model or its collection
       // will get re-rendered with the updated name as soon as this is called
-      this.props.userTodoModel.save({name: 'Giving This Todo A New Name})
-          .then(
-            () => notify('Todo save succeeded!'),
-            () => notify('Todo save failed :/')
-          ).then(() => this.setState({isSaving: false})
+      this.props.userTodoModel.save({name: 'Giving This Todo A New Name}, {
+        success: () => notify('Todo save succeeded!'),
+        error: () => notify('Todo save failed :/'),
+        complete: () => this.setState({isSaving: false})
+      });
     }
     ```
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,6 @@
 import {camelize, noOp} from './utils';
 import React from 'react';
+import Schmackbone from 'schmackbone';
 
 /**
  * This module contains all the required setup for implementing withResources
@@ -93,6 +94,11 @@ export const ResourcesConfig = {
   /** {function}: Hook to send errors to a logging service. */
   log: noOp,
   /**
+   * {function}: This is a facade for Schmackbone's .ajaxFilter. See documentation for usage at:
+   *     https://github.com/noahgrant/schmackbone#backboneajaxprefilter
+   */
+  prefilter: noOp,
+  /**
    * {string}: the name of the prop object that will contain url query
    * parameters. This object gets spread to flatten them as individual props
    * within a withResources client. default 'urlParams'.
@@ -106,6 +112,10 @@ export const ResourcesConfig = {
    *  ResourcesConfig configuration object
    */
   set(config) {
+    if (config.prefilter) {
+      Schmackbone.ajaxPrefilter = config.prefilter;
+    }
+
     return Object.assign(this, config);
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@ import {ModelMap, ResourceKeys, ResourcesConfig, UnfetchedResources} from './con
 import React, {useEffect, useReducer, useRef, useState} from 'react';
 
 import _ from 'underscore';
-import _prefetch from './prefetch';
 import ErrorBoundary from './error-boundary';
 import {LoadingStates} from './constants';
 import ModelCache from './model-cache';
@@ -977,4 +976,5 @@ function fetchResources(resources, props, {
   );
 }
 
-export const prefetch = _prefetch;
+export {default as prefetch} from './prefetch';
+export {Model, Collection} from 'schmackbone';

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,5 +1,5 @@
+import {Collection} from 'schmackbone';
 import ModelCache from './model-cache';
-import Schmackbone from 'schmackbone';
 
 const loadingCache = {};
 
@@ -8,7 +8,7 @@ const loadingCache = {};
  * application instead of importing the ModelCache directly.
  *
  * @param {string} key - cache lookup key
- * @return {Schmackbone.Model?|Schmackbone.Collection?} model instance from
+ * @return {Model?|Collection?} model instance from
  *   cache at the cache key if it exists
  */
 export const getFromCache = (key) => ModelCache.get(key);
@@ -24,7 +24,7 @@ export const getFromCache = (key) => ModelCache.get(key);
 export const existsInCache = (key) => !!ModelCache.get(key);
 
 /**
- * Main method for retrieving Schmackbone models/collections.
+ * Main method for retrieving models/collections.
  *
  * Note that it utilizes the loadingCache while a model is being fetched, and
  * removes it from the loadingCache before resolve or reject is called. This
@@ -32,7 +32,7 @@ export const existsInCache = (key) => !!ModelCache.get(key);
  * executed when the promise is fulfilled.
  *
  * @param {string} key - cache lookup key
- * @param {function} Model - the Schmackbone model constructor
+ * @param {function} Model - the model constructor
  * @param {object} options - options object used for fetching that can include:
  *
  *   * attributes {object} - attributes to pass a Model instance
@@ -44,8 +44,7 @@ export const existsInCache = (key) => !!ModelCache.get(key);
  *   * options {object} - options to pass to the Model constructor
  *   * prefetch {boolean} - whether the request should be treated as a prefetched resource
  *
- * @return {promise} a promise that will resolve with the new Schmackbone Model/
- *    Collection instance
+ * @return {promise} a promise that will resolve with the new Model/Collection instance
  */
 export default (key, Model, options={}) => {
   var model = ModelCache.get(key),
@@ -125,9 +124,9 @@ export default (key, Model, options={}) => {
  * Helper to determine whether to pass the `models` property or the `attributes`
  * value of an options hash as a model instantiation's first argument.
  *
- * @param {Schmackbone.Model|Schmackbone.Collection} Constructor - model constructor
+ * @param {Model|Collection} Constructor - model constructor
  * @return {string} property name to pass to model instantiation
  */
 function getFirstArgPropertyName(Constructor) {
-  return Constructor.prototype instanceof Schmackbone.Collection ? 'models' : 'attributes';
+  return Constructor.prototype instanceof Collection ? 'models' : 'attributes';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5651,26 +5651,25 @@
       }
     },
     "react": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "prop-types": "^15.6.2"
       }
     },
     "react-dom": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "scheduler": "^0.19.1"
       }
     },
     "react-is": {
@@ -5955,9 +5954,10 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "karma-jasmine": "^1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-webpack": "^3.0.5",
-    "react-dom": "^16.8.6",
+    "react-dom": "^16.13.1",
     "webpack": "^4.29.6"
   },
   "dependencies": {
     "@babel/runtime": "^7.4.5",
-    "react": "^16.8.6",
+    "react": "^16.13.1",
     "schmackbone": "^1.4.0",
     "underscore": "^1.8.3"
   }

--- a/test/config.js
+++ b/test/config.js
@@ -81,31 +81,40 @@ describe('Config', () => {
   describe('#setConfig', () => {
     it('adds a setting to the configs, overriding defaults', () => {
       var logSpy = jasmine.createSpy('log'),
-          trackSpy = jasmine.createSpy('track');
+          trackSpy = jasmine.createSpy('track'),
+          prefilterSpy = jasmine.createSpy('prefilter');
 
       expect(Config.ResourcesConfig.cacheGracePeriod).toEqual(120000);
       expect(Config.ResourcesConfig.log).toEqual(noOp);
+      expect(Config.ResourcesConfig.prefilter).toEqual(noOp);
       expect(Config.ResourcesConfig.track).toEqual(noOp);
       expect(Config.ResourcesConfig.queryParamsPropName).toEqual('urlParams');
+      // default is the identity fn
+      expect(Schmackbone.ajaxPrefilter('foo')).toEqual('foo');
 
       Config.ResourcesConfig.set({
         cacheGracePeriod: 300000,
         log: logSpy,
+        prefilter: prefilterSpy,
         track: trackSpy,
         queryParamsPropName: 'queryPs'
       });
 
       expect(Config.ResourcesConfig.cacheGracePeriod).toEqual(300000);
       expect(Config.ResourcesConfig.log).toEqual(logSpy);
+      expect(Config.ResourcesConfig.prefilter).toEqual(prefilterSpy);
       expect(Config.ResourcesConfig.track).toEqual(trackSpy);
       expect(Config.ResourcesConfig.queryParamsPropName).toEqual('queryPs');
+      expect(Schmackbone.ajaxPrefilter).toEqual(prefilterSpy);
 
       Config.ResourcesConfig.set({
         cacheGracePeriod: 120000,
         log: noOp,
+        prefilter: noOp,
         track: noOp,
         queryParamsPropName: 'queryParamsPropName'
       });
+      Schmackbone.ajaxPrefilter = (x) => x;
     });
   });
 });

--- a/test/with-resources.jsx
+++ b/test/with-resources.jsx
@@ -1,12 +1,15 @@
 import * as Request from '../lib/request';
 
-import {DecisionLogsCollection, UserModel} from './model-mocks';
 import {
+  prefetch as _prefetch,
+  Collection,
   EMPTY_COLLECTION,
   EMPTY_MODEL,
   getCacheKey,
+  Model,
   withResources
 } from '../lib/index';
+import {DecisionLogsCollection, UserModel} from './model-mocks';
 import {
   findDataCarrier,
   findDataChild,
@@ -24,6 +27,7 @@ import {
 import ErrorBoundary from '../lib/error-boundary';
 import {LoadingStates} from '../lib/constants';
 import ModelCache from '../lib/model-cache';
+import prefetch from '../lib/prefetch';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Schmackbone from 'schmackbone';
@@ -121,7 +125,7 @@ describe('withResources', () => {
 
     document.body.appendChild(jasmineNode);
 
-    requestSpy = spyOn(Request, 'default').and.callFake((key, Model, options) => {
+    requestSpy = spyOn(Request, 'default').and.callFake((key, Const, options) => {
       // mock fetch model cache behavior, where we put it in the cache immediately,
       // then request the model, and only if it errors do we remove it from cache
       var model = new Schmackbone.Model({key, ...(options.data || {})});
@@ -980,7 +984,7 @@ describe('withResources', () => {
             haveCalledPrefetch,
             haveCalledSearchQuery;
 
-        requestSpy.and.callFake((key, Model, options={}) => new Promise((res, rej) => {
+        requestSpy.and.callFake((key, Const, options={}) => new Promise((res, rej) => {
           window.requestAnimationFrame(() => {
             var model = new Schmackbone.Model({key, ...(options.data || {})});
 
@@ -1288,6 +1292,12 @@ describe('withResources', () => {
         done();
       });
     });
+  });
+
+  it('exports Model and Collection constructors directly', () => {
+    expect(_prefetch).toEqual(prefetch);
+    expect(Model).toEqual(Schmackbone.Model);
+    expect(Collection).toEqual(Schmackbone.Collection);
   });
 });
 /* eslint-enable max-nested-callbacks */


### PR DESCRIPTION
In effort to reduce the number of Schmackbone imports in application development:

## Description of Proposed Changes:  
  -  Exports `Model` and `Collection` constructors directly from Schmackbone
  -  Allows for setting a `prefilter` config option that is a proxy for `Schmackbone.ajaxPrefilter`
 
