### PR TITLE
support for schmackbone 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Additional features include:
 * updating a component when a resource updates
 * ...and more
 
-It employs a View-less, jQuery-less fork of Backbone called [Schmackbone](https://github.com/noahgrant/schmackbone) for Model/Collection semantics (as well as its [Events module](https://backbonejs.org/#Events)). Getting started is easy:
+It employs a View-less, jQuery-less, Promise-interfaced fork of Backbone called [Schmackbone](https://github.com/noahgrant/schmackbone) for Model/Collection semantics (as well as its [Events module](https://backbonejs.org/#Events)). Getting started is easy:
 
 1. Define a model in your application:
 
@@ -881,11 +881,10 @@ ResourcesConfig.set(configObj);
   
       // any other mounted component in the application listening to this model or its collection
       // will get re-rendered with the updated name as soon as this is called
-      this.props.userTodoModel.save({name: 'Giving This Todo A New Name}, {
-        success: () => notify('Todo save succeeded!'),
-        error: () => notify('Todo save failed :/'),
-        complete: () => this.setState({isSaving: false})
-      });
+      this.props.userTodoModel.save({name: 'Giving This Todo A New Name})
+          .then(() => notify('Todo save succeeded!'))
+          .catch(() => notify('Todo save failed :/'))
+          .then(() => this.setState({isSaving: false}));
     }
     ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -208,18 +208,18 @@ export const withResources = (getResources) =>
           isCurrentResource: ([name, config], cacheKey) => this._isMounted && !config.prefetch &&
             cacheKey === this._findCurrentCacheKey([name, config]),
           setResourceState: props.setResourceState,
-          onRequestSuccess: (model, [name, config]) => {
+          onRequestSuccess: (model, status, [name, config]) => {
             // set loading state _after_ all its dependencies are added
             this.setState({
               [getResourceState(name)]: LoadingStates.LOADED,
-              ...(config.status ? {[getResourceStatus(name)]: model.status} : {})
+              ...(config.status ? {[getResourceStatus(name)]: status} : {})
             });
           },
-          onRequestFailure: (model, [name, config]) => {
+          onRequestFailure: (model, status, [name, config]) => {
             // this catch block gets called _only_ for request errors.
             this.setState({
               [getResourceState(name)]: LoadingStates.ERROR,
-              ...(config.status ? {[getResourceStatus(name)]: model.status} : {})
+              ...(config.status ? {[getResourceStatus(name)]: status} : {})
             });
           }
         }).then(() => {
@@ -405,7 +405,7 @@ export const useResources = (getResources, props) => {
         isCurrentResource: ([name, config], cacheKey) => isMountedRef.current && !config.prefetch &&
           cacheKey === findCacheKey([name, config], getResources, currentPropsRef.current),
         setResourceState,
-        onRequestSuccess: (model, [name, config]) => {
+        onRequestSuccess: (model, status, [name, config]) => {
           // to batch these state updates into one, per this comment:
           // https://stackoverflow.com/questions/48563650/
           // does-react-keep-the-order-for-state-updates/48610973#48610973
@@ -416,13 +416,13 @@ export const useResources = (getResources, props) => {
 
             loaderDispatch({
               type: LoadingStates.LOADED,
-              payload: {name, config, model, resources}
+              payload: {name, config, status, resources}
             });
           });
         },
-        onRequestFailure: (model, [name, config]) => loaderDispatch({
+        onRequestFailure: (model, status, [name, config]) => loaderDispatch({
           type: LoadingStates.ERROR,
-          payload: {name, config, model}
+          payload: {name, config, status}
         })
       }).then(() => {
         if (isMountedRef.current) {
@@ -834,7 +834,7 @@ function loaderReducer(
   {loadingStates, requestStatuses, hasInitiallyLoaded},
   {type, payload={}}
 ) {
-  var {name, model={}, resources} = payload;
+  var {name, status, resources} = payload;
 
   switch (type) {
     case LoadingStates.ERROR:
@@ -843,7 +843,7 @@ function loaderReducer(
 
       return {
         loadingStates: nextLoadingStates,
-        requestStatuses: {...requestStatuses, [getResourceStatus(name)]: model.status},
+        requestStatuses: {...requestStatuses, [getResourceStatus(name)]: status},
         hasInitiallyLoaded: hasInitiallyLoaded || (type === LoadingStates.LOADED &&
           hasLoaded(getCriticalLoadingStates(nextLoadingStates, resources)) && !hasInitiallyLoaded)
       };
@@ -915,7 +915,7 @@ function fetchResources(resources, props, {
         ...rest
       }).then(
         // success callback, where we track request time and add any dependent props or models
-        (model) => {
+        ([model, status]) => {
           if (shouldMeasure) {
             trackRequestTime(name, config);
           }
@@ -959,16 +959,16 @@ function fetchResources(resources, props, {
               }));
             }
 
-            onRequestSuccess(model, [name, config]);
+            onRequestSuccess(model, status, [name, config]);
           }
         },
 
         // error callback
-        (model) => {
+        ([model, status]) => {
           // this catch block gets called _only_ for request errors.
           // don't set error state unless resource is current
           if (isCurrentResource([name, config], cacheKey)) {
-            onRequestFailure(model, [name, config]);
+            onRequestFailure(model, status, [name, config]);
           }
         }
       );

--- a/lib/request.js
+++ b/lib/request.js
@@ -70,27 +70,22 @@ export default (key, Model, options={}) => {
         if (options.fetch) {
           addToLoadingCache = true;
 
-          model.fetch({
-            data: options.data,
-            success: (newModel, json, opts={}) => {
+          model.fetch({data: options.data, type: options.method}).then(
+            ([newModel, json, opts={}]) => {
               delete loadingCache[key];
-              // TODO: resolve an array here, with status as an entry instead?
-              newModel.status = (opts.response || {}).status;
-              resolve(newModel);
+              resolve([newModel, (opts.response || {}).status]);
             },
-            error: (newModel, response={}, opts={}) => {
+            ([newModel, response={}, opts={}]) => {
               delete loadingCache[key];
 
               // don't cache errored requests
               ModelCache.remove(key);
 
-              newModel.status = response.status;
-              reject(newModel);
-            },
-            type: options.method
-          });
+              reject([newModel, response.status]);
+            }
+          );
         } else {
-          resolve(model);
+          resolve([model]);
         }
       } else {
         // this will cancel any in-flight timeouts and add the component
@@ -99,7 +94,7 @@ export default (key, Model, options={}) => {
 
         // the model has been fetched and is stored in the cache, so just
         // immediately resolve with that as our value
-        resolve(model);
+        resolve([model]);
       }
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1926,8 +1926,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -2144,8 +2143,7 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -5948,12 +5946,30 @@
       }
     },
     "schmackbone": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/schmackbone/-/schmackbone-1.4.0.tgz",
-      "integrity": "sha512-YAONS/1ku4baW39IrUKX/cVp+fdA+MPQBSv+hMZI9Q8KSpWTtugeBFVXdVY2/cgQ5SzyYrYIP0dOt1cGiMi08A==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/schmackbone/-/schmackbone-1.5.1.tgz",
+      "integrity": "sha512-FCK1Yib6nUZ+vc+wd2bXEB8OGwJ9uGXF9XSQ9SeOLWO8Qne9hblp6GLgmNfXKnA21cvzhgHjhtBFw9KpT2mAHA==",
       "requires": {
         "qs": "^6.5.2",
+        "terser": "^4.6.12",
         "underscore": ">=1.8.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "terser": {
+          "version": "4.6.13",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
+          "integrity": "sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==",
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          }
+        }
       }
     },
     "semver": {
@@ -6278,7 +6294,6 @@
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
       "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -6287,8 +6302,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.4.5",
-    "schmackbone": "^1.4.0",
+    "schmackbone": "^1.5.1",
     "underscore": "^1.8.3"
   },
   "peerDependencies": {

--- a/test/use-resources.jsx
+++ b/test/use-resources.jsx
@@ -110,13 +110,13 @@ describe('useResources', () => {
           return window.setTimeout(() => {
             delayedResourceComplete = true;
             ModelCache.remove(key);
-            rej(model);
+            rej([model]);
           }, options.options.delay);
         }
 
         if (cached) {
           // treat model as though it were cached by resolving promise immediately
-          return res(model);
+          return res([model]);
         }
 
         // put requests in a RAF to 'mimic' the procession of non-cached
@@ -124,13 +124,11 @@ describe('useResources', () => {
         // resolve the promise)
         window.requestAnimationFrame(() => {
           if (shouldResourcesError || (options.options || {}).shouldError) {
-            model.status = 404;
             ModelCache.remove(key);
 
-            rej(model);
+            rej([model, 404]);
           } else {
-            model.status = 200;
-            res(model);
+            res([model, 200]);
           }
         });
       });
@@ -903,11 +901,11 @@ describe('useResources', () => {
               if (prefetchLoading) {
                 return false;
               } else if (prefetchError) {
-                return rej(model);
+                return rej([model]);
               }
 
               ModelCache.put(key, model, options.component);
-              res(model);
+              res([model]);
             } else {
               if (/searchQuery/.test(key) && searchQueryLoading) {
                 haveCalledSearchQuery = true;
@@ -916,7 +914,7 @@ describe('useResources', () => {
               }
 
               ModelCache.put(key, model, options.component);
-              res(model);
+              res([model]);
             }
           });
         }));

--- a/test/with-resources.jsx
+++ b/test/with-resources.jsx
@@ -137,13 +137,13 @@ describe('withResources', () => {
           return window.setTimeout(() => {
             delayedResourceComplete = true;
             ModelCache.remove(key);
-            rej(model);
+            rej([model]);
           }, options.options.delay);
         }
 
         if (cached) {
           // treat model as though it were cached by resolving promise immediately
-          return res(model);
+          return res([model]);
         }
 
         // put requests in a RAF to 'mimic' the procession of non-cached
@@ -151,19 +151,11 @@ describe('withResources', () => {
         // resolve the promise)
         window.requestAnimationFrame(() => {
           if (shouldResourcesError) {
-            if (model !== EMPTY_COLLECTION && model !== EMPTY_MODEL) {
-              model.status = 404;
-            }
-
             ModelCache.remove(key);
 
-            rej(model);
+            rej([model, model !== EMPTY_COLLECTION && model !== EMPTY_MODEL ? 404 : null]);
           } else {
-            if (model !== EMPTY_COLLECTION && model !== EMPTY_MODEL) {
-              model.status = 200;
-            }
-
-            res(model);
+            res([model, model !== EMPTY_COLLECTION && model !== EMPTY_MODEL ? 200 : null]);
           }
         });
       });
@@ -995,11 +987,11 @@ describe('withResources', () => {
               if (prefetchLoading) {
                 return false;
               } else if (prefetchError) {
-                return rej(model);
+                return rej([model]);
               }
 
               ModelCache.put(key, model, options.component);
-              res(model);
+              res([model]);
             } else {
               if (/searchQuery/.test(key) && searchQueryLoading) {
                 haveCalledSearchQuery = true;
@@ -1008,7 +1000,7 @@ describe('withResources', () => {
               }
 
               ModelCache.put(key, model, options.component);
-              res(model);
+              res([model]);
             }
           });
         }));


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
Adds support for schmackbone 1.5, which provides Promise interfaces for requests

## Description of Proposed Changes:  
  -  replaces `success`/`error` fetch callbacks within `request.js` with `.then` handlers that both accept the array of values now passed by Schmackbone
  -  those handlers also themselves resolve an array of values, addressing a long-standing TODO of splitting up the model and its status
  -  Updates documentation
