### PR TITLE
listen on collection update and reset events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -431,7 +431,8 @@ export const useResources = (getResources, props) => {
               .filter(Boolean)
               .forEach((model) => {
                 model.off();
-                model.on('change sync destroy', forceUpdate, model);
+                // `update` includes `add` and `remove` collection events
+                model.on('change sync destroy update reset', forceUpdate, model);
               });
         }
       });

--- a/lib/schmackbone-mixin.js
+++ b/lib/schmackbone-mixin.js
@@ -54,9 +54,11 @@ export default mixin({
     // update. default component to force update is the component that
     // backboneMixin is applied to, but can be overridden by specifying a
     // `schmackboneContext` property.
-    modelsToAttach.forEach(
-      (model) => model.on('change sync destroy', onModelEvent, this.schmackboneContext || this)
-    );
+    modelsToAttach.forEach((model) => model.on(
+      'change sync destroy update reset',
+      onModelEvent,
+      this.schmackboneContext || this
+    ));
 
     this._attachedModels = modelsToAttach;
   }
@@ -87,9 +89,11 @@ function detectBackboneModels(component) {
 function _unattachModelListeners() {
   // Ensure that we clean up any dangling references when the component is
   // destroyed.
-  (this._attachedModels || []).forEach(
-    (model) => model.off('change sync destroy', onModelEvent, this.schmackboneContext || this)
-  );
+  (this._attachedModels || []).forEach((model) => model.off(
+    'change sync destroy update reset',
+    onModelEvent,
+    this.schmackboneContext || this
+  ));
   this._attachedModels = null;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/schmackbone-mixin.js
+++ b/test/schmackbone-mixin.js
@@ -35,13 +35,17 @@ describe('SchmackboneMixin', () => {
     dummyComponent.componentWillUnmount();
   });
 
-  it('calls the component\'s forceUpdate when any of its models sync, change, or destroy', () => {
+  it('calls the component\'s forceUpdate when any of its models trigger listened events', () => {
     model1.trigger('sync');
     expect(forceUpdateSpy).toHaveBeenCalled();
     model2.trigger('change');
     expect(forceUpdateSpy.calls.count()).toEqual(2);
     model3.trigger('destroy');
     expect(forceUpdateSpy.calls.count()).toEqual(3);
+    model1.trigger('update');
+    expect(forceUpdateSpy.calls.count()).toEqual(4);
+    model1.trigger('reset');
+    expect(forceUpdateSpy.calls.count()).toEqual(5);
   });
 
   it('removes event listeners before the component unmounts', () => {
@@ -51,6 +55,10 @@ describe('SchmackboneMixin', () => {
     model2.trigger('change');
     expect(forceUpdateSpy).not.toHaveBeenCalled();
     model3.trigger('destroy');
+    expect(forceUpdateSpy).not.toHaveBeenCalled();
+    model1.trigger('update');
+    expect(forceUpdateSpy).not.toHaveBeenCalled();
+    model2.trigger('reset');
     expect(forceUpdateSpy).not.toHaveBeenCalled();
   });
 

--- a/test/use-resources.jsx
+++ b/test/use-resources.jsx
@@ -27,7 +27,6 @@ const getResources = (props) => ({
   [ResourceKeys.ANALYSTS]: {noncritical: true, options: {noResolve: props.noResolve}},
   [ResourceKeys.DECISIONS]: {
     ...(props.includeDeleted ? {data: {include_deleted: true}} : {}),
-    listen: true,
     measure
   },
   [ResourceKeys.NOTES]: {noncritical: true, dependsOn: ['noah']},
@@ -1012,7 +1011,11 @@ describe('useResources', () => {
     async(done) => {
       dataChild = findDataChild(renderUseResources({customName: true}));
 
-      await waitsFor(() => requestSpy.calls.count() === 4);
+      expect(dataChild.props.decisionsLoadingState).toEqual('loading');
+      expect(dataChild.props.customDecisionsLoadingState).toEqual('loading');
+      expect(dataChild.props.sift).not.toBeDefined();
+
+      await waitsFor(() => dataChild.props.hasLoaded);
 
       expect(requestSpy.calls.all().map((call) => call.args[0])).toEqual([
         'decisions',
@@ -1021,11 +1024,6 @@ describe('useResources', () => {
         'analysts'
       ]);
 
-      expect(dataChild.props.decisionsLoadingState).toEqual('loading');
-      expect(dataChild.props.customDecisionsLoadingState).toEqual('loading');
-      expect(dataChild.props.sift).not.toBeDefined();
-
-      await waitsFor(() => dataChild.props.hasLoaded);
       expect(dataChild.props.decisionsCollection.get('key')).toEqual('decisions');
       // key should be the same as for decisions, signaling that while fetch is
       // called ones for each resource, only one fetch would be made


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

When models are added or removed from a collection, any listening components do not get re-rendered. I believe this is a long-standing issue as I remember coming across this often and getting around with a manual `sync` call:

```js
myCollection.add(newModel).trigger('sync');
```

This is because, other than `sync`, models only ever listen to events triggered on models themselves—`change` and `destroy`. This events do bubble up to their collections, but when calling `add`, `remove`, or `reset` on the collection itself, none of the listened-on events get triggered.

## Description of Proposed Changes:  
  -  Adds `update` (which encompasses a collection's `add` and `remove` events) and `reset` events to the events we listen on for component updates.

