### PR TITLE
Listen on passed models

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import TodosCollection from 'js/models/todos-collection';
 ModelMap.add({TODOS: TodosCollection});
 ```
 
-```
+```js
 // in your top level js file
 import 'js/core/resourcerer-config;
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -357,6 +357,13 @@ export const useResources = (getResources, props) => {
       // setting any loaded or error states, that a returned resource belongs
       // to the most recent component props. so we use a ref to persist across the closure
       currentPropsRef = useRef(props),
+      // stash reference to all models with listeners currently attached, since when we return
+      // from any updated requests there's no guarantee that the most recent models were a
+      // function of the previous props (as opposed to props from two renders ago, for example).
+      // an edge case may be seen with resources that become pending or go from pending across
+      // renders. using this reference will guarantee that we always remove listeners from the
+      // correct models before attaching new listeners
+      listenedModelsRef = useRef([]),
 
       forceUpdate = useForceUpdate(),
       getPrevCacheKey = (rsrc) => findCacheKey(rsrc, getResources, prevPropsRef.current);
@@ -426,14 +433,21 @@ export const useResources = (getResources, props) => {
         })
       }).then(() => {
         if (isMountedRef.current) {
-          // attaches listeners on all resources
-          resources.map(([, config]) => getModelFromCache(config, props))
-              .filter(Boolean)
-              .forEach((model) => {
-                model.off();
-                // `update` includes `add` and `remove` collection events
-                model.on('change sync destroy update reset', forceUpdate, model);
-              });
+          // only get those from the cache. models in state might can empty models, but even so i
+          // think it would be preferable to use state (within a separate useEffect) to determine
+          // which models get listened to. but as mentioned, that would require the effect to depend
+          // on cache keys, which are dynamic, and effects can't have dynamic dependencies right now
+          let listenedModels = resources.map(([, config]) => getModelFromCache(config, props))
+              .filter(Boolean);
+
+          // remove previous listeners and attach new ones
+          listenedModelsRef.current.forEach((model) => model.off('all', forceUpdate, model));
+          listenedModels.forEach((model) => {
+            // `update` includes `add` and `remove` collection events
+            model.on('change sync destroy update reset', forceUpdate, model);
+          });
+
+          listenedModelsRef.current = listenedModels;
         }
       });
     }
@@ -441,13 +455,28 @@ export const useResources = (getResources, props) => {
     return () => prevPropsRef.current = props;
   });
 
-  // effect to simply unregister the component from all models and remove model
-  // listeners when unmounting
-  useEffect(() => () => {
-    ModelCache.unregister(componentRef.current);
-    resources.map(([, config]) => getModelFromCache(config, props))
-        .filter(Boolean)
-        .forEach((model) => model.off());
+  // this effect attaches listeners to any bypassed models (ie, those passed in) which don't get
+  // attached after a fetch call. additionally, the cleanup function unregisters the component from
+  // all models and removes model listeners from all resources when unmounting
+  useEffect(() => {
+    var bypassedModels = resources.filter(shouldBypassFetch.bind(null, props))
+        .map(([name, {modelKey}]) => props[getResourcePropertyName(name, modelKey)])
+        .filter(Boolean);
+
+    bypassedModels.forEach(
+      (model) => model.on('change sync destroy update reset', forceUpdate, model)
+    );
+
+    return () => {
+      ModelCache.unregister(componentRef.current);
+      // use _current_ props when getting the models here, because if any have changed over the
+      // lifecycle of the component then they should have already had listeners removed. this only
+      // removes listeners from the 'last' batch before unmounting
+      resources.map(([, config]) => getModelFromCache(config, currentPropsRef.current))
+          .filter(Boolean)
+          .concat(bypassedModels)
+          .forEach((model) => model.off('all', forceUpdate, model));
+    };
   }, []);
 
   currentPropsRef.current = props;
@@ -863,7 +892,7 @@ function loaderReducer(
 /**
  * Here's where we do the fetching for a given set of resources. We combine the
  * promises into a single Promise.all so that we wait until all fetches complete
- * before listenting on any of them. Note that Promise.all takes the promise
+ * before listening on any of them. Note that Promise.all takes the promise
  * returned from the fetch's catch method, so that even if a request fails,
  * Promise.all will not reject.
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
* issue where unmounting a component unsubscribes its models from all events
* issue where passed-in models (via props) are not listened on
