### PR TITLE
auto-listening for withResources

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,7 @@ const resourceState = (Component) =>
  * several different data-related things for a component automatically:
  *
  *   1. it fetches a component's resources in cWM
- *   2. it binds schmackboneMixin listeners to any resource with a `listen: true` option
+ *   2. it binds schmackboneMixin listeners to all resources
  *   3. it handles whether or not the critical resources for a component have loaded
  *   4. it re-fetches a new resource in cWRP when specified props have changed
  *   5. it handles resource cache naming for the ModelCache
@@ -91,8 +91,6 @@ const resourceState = (Component) =>
  *   * noncritical {boolean} - whether the resource should not be taken into
  *        account when determining the loading state of the component. default
  *        is false
- *   * listen {boolean} - whether the component should re-render on changes to
- *        the resource
  *   * data {object} - data for the fetch call passed to the `request`
  *   * options {object} - options object passed to the model's `initialize`
  *   * dependsOn {string[]} - prop fields required to be present before the
@@ -153,7 +151,7 @@ export const withResources = (getResources) =>
 
         this._getBackboneModels = () =>
           this._generateResources()
-              .filter(([, config]) => config.listen && getModelFromCache(config, this.props))
+              .filter(([, config]) => getModelFromCache(config, this.props))
               .map(([, config]) => getModelFromCache(config, this.props));
       }
 
@@ -224,8 +222,7 @@ export const withResources = (getResources) =>
           }
         }).then(() => {
           if (this._isMounted) {
-            // attaches listeners on all resources with listen: true as defined
-            // by this._getBackboneModels
+            // attaches listeners on all resources as defined by this._getBackboneModels
             this._attachModelListeners();
           }
         });
@@ -892,9 +889,9 @@ function loaderReducer(
 /**
  * Here's where we do the fetching for a given set of resources. We combine the
  * promises into a single Promise.all so that we wait until all fetches complete
- * before listening on any of them. Note that Promise.all takes the promise
- * returned from the fetch's catch method, so that even if a request fails,
- * Promise.all will not reject.
+ * before listening on them. Note that Promise.all takes the promise returned
+ * from the fetch's catch method, so that even if a request fails, Promise.all
+ * will not reject.
  *
  * @param {array[]} resources - list of resource config entries for fetching
  * @param {object} props - current component props


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
- It's cumbersome to know when to listen to a model, and the cost of listening to all models is very very low in terms of memory footprint. This PR does like the useResources hook and auto-listens to all resources for the HOC

## Description of Proposed Changes:  
  -  removes the `{listen: true}` requirement for listening on a resource for `withResources`
  -  updates documentation to remove any notion of that flag
  
