### PR TITLE
components can be initially loaded on first render

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -718,11 +718,11 @@ function findCacheKey(resource, getResources, props) {
  *    state as values
  */
 function buildResourcesLoadingState(resources, props) {
-  return resources.reduce((state, [name, config]) => ({
-    ...state,
-    [getResourceState(name)]: shouldBypassFetch(props, [name, config]) ?
-      LoadingStates.LOADED :
-      (!hasAllDependencies(props, [, config]) ? LoadingStates.PENDING : LoadingStates.LOADING)
+  return resources.reduce((state, [name, config]) => Object.assign(state, {
+    [getResourceState(name)]:
+      shouldBypassFetch(props, [name, config]) || getModelFromCache(config, props) ?
+        LoadingStates.LOADED :
+        (!hasAllDependencies(props, [, config]) ? LoadingStates.PENDING : LoadingStates.LOADING)
   }), {});
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/use-resources.jsx
+++ b/test/use-resources.jsx
@@ -196,21 +196,43 @@ describe('useResources', () => {
     done();
   });
 
-  it('\'hasInitiallyLoaded\' is initially true if all critical models are passed', () => {
-    dataChild = findDataChild(renderUseResources({
-      decisionsCollection: new Schmackbone.Collection(),
-      userModel: new Schmackbone.Model()
-    }));
+  describe('\'hasInitiallyLoaded\' is initially true', () => {
+    it('if all critical models are passed', () => {
+      dataChild = findDataChild(renderUseResources({
+        decisionsCollection: new Schmackbone.Collection(),
+        userModel: new Schmackbone.Model()
+      }));
 
-    expect(dataChild.props.hasInitiallyLoaded).toBe(true);
-    unmountAndClearModelCache();
+      expect(dataChild.props.hasInitiallyLoaded).toBe(true);
+      unmountAndClearModelCache();
 
-    dataChild = findDataChild(renderUseResources({
-      // analystsCollection is noncritical
-      analystsCollection: new Schmackbone.Collection(),
-      userModel: new Schmackbone.Model()
-    }));
-    expect(dataChild.props.hasInitiallyLoaded).toBe(false);
+      dataChild = findDataChild(renderUseResources({
+        // analystsCollection is noncritical
+        analystsCollection: new Schmackbone.Collection(),
+        userModel: new Schmackbone.Model()
+      }));
+      expect(dataChild.props.hasInitiallyLoaded).toBe(false);
+    });
+
+    it('if the critical models already exist in the cache', () => {
+      var decisionsCollection = new Schmackbone.Collection(),
+          userModel = new Schmackbone.Model();
+
+      ModelCache.put('decisions', decisionsCollection);
+      ModelCache.put('userfraudLevel=high_userId=noah', userModel);
+      dataChild = findDataChild(renderUseResources());
+
+      expect(dataChild.props.hasLoaded).toBe(true);
+      expect(dataChild.props.hasInitiallyLoaded).toBe(true);
+      expect(dataChild.props.decisionsCollection).toEqual(decisionsCollection);
+      expect(dataChild.props.userModel).toEqual(userModel);
+      unmountAndClearModelCache();
+
+      ModelCache.remove('userfraudLevel=high_userId=noah');
+      dataChild = findDataChild(renderUseResources());
+      expect(dataChild.props.hasLoaded).toBe(false);
+      expect(dataChild.props.hasInitiallyLoaded).toBe(false);
+    });
   });
 
   it('resource keys get turned into props of the same name, with \'Model\' or ' +
@@ -1009,7 +1031,7 @@ describe('useResources', () => {
         await waitsFor(() => dataChild.props.searchQueryModel && haveCalledPrefetch);
         expect(dataChild.props.hasLoaded).toBe(true);
 
-        ReactDOM.unmountComponentAtNode(jasmineNode);
+        unmountAndClearModelCache();
         prefetchLoading = false;
         prefetchError = true;
         haveCalledPrefetch = false;
@@ -1019,7 +1041,7 @@ describe('useResources', () => {
         await waitsFor(() => dataChild.props.searchQueryModel && haveCalledPrefetch);
         expect(dataChild.props.hasLoaded).toBe(true);
 
-        ReactDOM.unmountComponentAtNode(jasmineNode);
+        unmountAndClearModelCache();
         prefetchError = false;
         searchQueryLoading = true;
         haveCalledPrefetch = false;

--- a/test/with-resources.jsx
+++ b/test/with-resources.jsx
@@ -1074,7 +1074,7 @@ describe('withResources', () => {
         await waitsFor(() => dataChild.props.searchQueryModel && haveCalledPrefetch);
         expect(dataChild.props.hasLoaded).toBe(true);
 
-        ReactDOM.unmountComponentAtNode(jasmineNode);
+        unmountAndClearModelCache();
         prefetchLoading = false;
         prefetchError = true;
         haveCalledPrefetch = false;
@@ -1084,7 +1084,7 @@ describe('withResources', () => {
         await waitsFor(() => dataChild.props.searchQueryModel && haveCalledPrefetch);
         expect(dataChild.props.hasLoaded).toBe(true);
 
-        ReactDOM.unmountComponentAtNode(jasmineNode);
+        unmountAndClearModelCache();
         prefetchError = false;
         searchQueryLoading = true;
         haveCalledPrefetch = false;
@@ -1208,6 +1208,12 @@ describe('withResources', () => {
     });
 
   describe('wrapping stateless functional components', () => {
+    beforeEach(() => {
+      // TODO: unclear why this needs to be removed explicitly instead of relying
+      // on unmountAndClearModelCache
+      ModelCache.remove('useruserId=noah');
+    });
+
     it('receive props normally', async(done) => {
       var FunctionComponent = (props) =>
             props.isLoading ?


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
Fixes a longstanding issue where each component was always initially rendered in a loading state even if all critical models existed in the cache. The component would then render as loaded in the following frame. Now it will render as loaded immediately.

## Description of Proposed Changes:  
  -  the `buildResourcesLoadingState` function returned `LOADED` only for resources passed in; now it also returns `LOADED` if in the ModelCache
