### PR TITLE
initial model state should not take prefetch into account

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -365,7 +365,7 @@ export const useResources = (getResources, props) => {
       // show an empty model as a resource is being requested instead of
       // continuing to show the previous model. on the plus side, setting them
       // as state means we won't need a loading overlay component to do this for us
-      [models, setModels] = useState(modelAggregator(resources, props)),
+      [models, setModels] = useState(modelAggregator(resources.filter(withoutPrefetch), props)),
 
       isMountedRef = useIsMounted(false),
       // this is used as an identifier to this component instance to register


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
prefetched models would temporarily override current models in model state

