### PR TITLE
Empty instances

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,6 +24,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci && npm i react react-dom
+    - run: npm ci && npm i react@16 react-dom@16
     - run: npm run lint
     - run: npm test

--- a/ADVANCED_TOPICS.md
+++ b/ADVANCED_TOPICS.md
@@ -13,11 +13,19 @@ Using `dependsOn` in simple cases like the one highlighted in the [README](https
 
 1. `PENDING` critical resources don’t contribute to `isLoading`/`hasErrored` states, but will keep your component from reaching a `hasLoaded` state. Semantically, this makes sense, because `this.props.hasLoaded` should only be true when all critical resources have loaded, regardless of when a resource’s request is made.
     
-1. When a `PENDING` resource request is not in flight, its model prop will be an empty Model/Collection whose properties are frozen (the same empty model prop is passed when the resource has `ERRORED`). This is to more predictably handle our resources in our components. We don’t need to be defensive with syntax like:
+1. When a `PENDING` resource request is not in flight, its model prop will be an empty model instance whose properties are frozen (the same happens when the resource has `ERRORED`). This is to more predictably handle our resources in our components. We don’t need to be defensive with syntax like:
 
-     `this.props.todosCollection && this.props.todosCollection.toJSON()`. 
+   ```js
+   this.props.todosCollection && this.props.todosCollection.toJSON(); // unnecessary
+   ```
+
+   Furthermore, if you've defined additional instance methods on your model, they will be present without being defensive:
+
+   ```js
+   this.props.todosCollection.myInstanceMethod(); // guaranteed not to error regardless of loading state
+   ```
     
-    1. When a resource is `LOADING`, its model prop will be an empty Model/Collection, but it will be the same instance of the model that will be populated when it is `LOADED` (this is an implementation detail that will likely never need to be considered in development).
+    1. When a resource is `LOADING`, its model prop will likely be the same empty model instance as in the `PENDING`/`ERRORED` state. I say likely because just before fetching, a new model is instantiated and put in the cache, initialized with any data passed to it via the executor function. However, unless your component re-renders between requesting and returning, that model won't get surfaced to the component until after returning. This instance is the same instance of the model that will be populated when it is `LOADED`. This is all an implementation detail that will likely never need to be considered in development.
         
 1. When a previously-`PENDING` but currently `LOADED` resource has its dependent prop removed, it goes back to a `PENDING` state (recall that if the dependent prop is changed, it gets put back into a `LOADING` state while the new resource is fetched). This puts us in an interesting state:
     

--- a/ADVANCED_TOPICS.md
+++ b/ADVANCED_TOPICS.md
@@ -11,6 +11,7 @@
 Using `dependsOn` in simple cases like the one highlighted in the [README](https://github.com/noahgrant/resourcerer/blob/master/README.md) is pretty straightforward and very powerful. But `PENDING` resources bring additional complexities to your resource logic, some of which are enumerated here:
 
 
+
 1. `PENDING` critical resources don’t contribute to `isLoading`/`hasErrored` states, but will keep your component from reaching a `hasLoaded` state. Semantically, this makes sense, because `this.props.hasLoaded` should only be true when all critical resources have loaded, regardless of when a resource’s request is made.
     
 1. When a `PENDING` resource request is not in flight, its model prop will be an empty model instance whose properties are frozen (the same happens when the resource has `ERRORED`). This is to more predictably handle our resources in our components. We don’t need to be defensive with syntax like:

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,15 +12,6 @@ import schmackboneMixin from './schmackbone-mixin';
 
 const SPREAD_PROVIDES_CHAR = '_';
 
-// pending and errored resources are not cached, but instead of passing down an
-// undefined prop, we pass down empty models for greater defense in client code
-export const EMPTY_MODEL = Object.freeze(new Schmackbone.Model());
-export const EMPTY_COLLECTION = Object.freeze(new Schmackbone.Collection());
-
-// ensure that no withResources client can modify empty models' data
-Object.freeze(EMPTY_MODEL.attributes);
-Object.freeze(EMPTY_COLLECTION.models);
-
 /**
  * This HOC is a light wrapper around the DataCarrier component for setting
  * state that should trigger resource updates. Some things won't need this, ie
@@ -608,19 +599,26 @@ function getResourcePropertyName(baseName, modelKey) {
 /**
  * When a resource is not found in the ModelCache, withResources returns a
  * default empty resource so that clients can assume the model is defined
- * without needing to be defensive. This method determines whether the Backbone
- * Model or the Backbone Collection should be passed down for a given resource.
- *
- * TODO: should we go further and pass down empty instance of the specific
- *   constructor instead of a generic model/collection?
+ * without needing to be defensive. This method freezes an empty instance of
+ * the model associated with the modelKey and returns it.
  *
  * @param {string} modelKey - resource type key
  * @return {Schmackbone.Model|Schmackbone.Collection} frozen empty model or collection instance
  */
 function getEmptyModel(modelKey) {
-  var Constructor = ModelMap[modelKey];
+  var Model = typeof ModelMap[modelKey] === 'function' ? ModelMap[modelKey] : Schmackbone.Model,
+      emptyInstance = new Model(),
+      FROZEN_EMPTY_MODEL;
 
-  return Constructor.prototype instanceof Schmackbone.Collection ? EMPTY_COLLECTION : EMPTY_MODEL;
+  // flag to differentiate between other model instances that happen to be empty
+  emptyInstance.isEmptyModel = true;
+  FROZEN_EMPTY_MODEL = Object.freeze(emptyInstance);
+
+  // ensure that no resourcerer client can modify empty model's data
+  Object.freeze(FROZEN_EMPTY_MODEL.attributes);
+  Object.freeze(FROZEN_EMPTY_MODEL.models);
+
+  return FROZEN_EMPTY_MODEL;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/use-resources.jsx
+++ b/test/use-resources.jsx
@@ -1,12 +1,7 @@
 import * as Request from '../lib/request';
 
-import {DecisionsCollection, UserModel} from './model-mocks';
-import {
-  EMPTY_COLLECTION,
-  EMPTY_MODEL,
-  getCacheKey,
-  useResources
-} from '../lib/index';
+import {DecisionsCollection, NotesModel, UserModel} from './model-mocks';
+import {getCacheKey, useResources} from '../lib/index';
 import {hasErrored, hasLoaded, isLoading, noOp} from '../lib/utils';
 import {ModelMap, ResourceKeys, ResourcesConfig} from '../lib/config';
 
@@ -593,11 +588,12 @@ describe('useResources', () => {
       await waitsFor(() => dataChild.props.hasLoaded);
       // these are our two critical resources, whose models have been placed in
       // the cache before fetching
-      expect(dataChild.props.decisionsCollection).not.toEqual(EMPTY_COLLECTION);
-      expect(dataChild.props.userModel).not.toEqual(EMPTY_MODEL);
+      expect(dataChild.props.decisionsCollection.isEmptyModel).not.toBeDefined();
+      expect(dataChild.props.userModel.isEmptyModel).not.toBeDefined();
 
       // however, this is a pending resource, so it should not be in the cache
-      expect(dataChild.props.notesModel).toEqual(EMPTY_MODEL);
+      expect(dataChild.props.notesModel.isEmptyModel).toBe(true);
+      expect(dataChild.props.notesModel instanceof NotesModel).toBe(true);
 
       unmountAndClearModelCache();
 
@@ -607,8 +603,11 @@ describe('useResources', () => {
 
       await waitsFor(() => dataChild.props.hasErrored);
 
-      expect(dataChild.props.decisionsCollection).toEqual(EMPTY_COLLECTION);
-      expect(dataChild.props.userModel).toEqual(EMPTY_MODEL);
+      expect(dataChild.props.decisionsCollection.isEmptyModel).toBe(true);
+      expect(dataChild.props.decisionsCollection instanceof DecisionsCollection).toBe(true);
+
+      expect(dataChild.props.userModel.isEmptyModel).toBe(true);
+      expect(dataChild.props.userModel instanceof UserModel).toBe(true);
       done();
     });
 
@@ -919,7 +918,7 @@ describe('useResources', () => {
       // we have a new model cache key for the dependent model because
       // the value of serialProp has changed. so the cache lookup should
       // again be empty
-      expect(dataChild.props.decisionLogsCollection).toEqual(EMPTY_COLLECTION);
+      expect(dataChild.props.decisionLogsCollection.isEmptyModel).toBe(true);
       done();
     });
   });

--- a/test/with-resources.jsx
+++ b/test/with-resources.jsx
@@ -3,13 +3,11 @@ import * as Request from '../lib/request';
 import {
   prefetch as _prefetch,
   Collection,
-  EMPTY_COLLECTION,
-  EMPTY_MODEL,
   getCacheKey,
   Model,
   withResources
 } from '../lib/index';
-import {DecisionLogsCollection, DecisionsCollection, UserModel} from './model-mocks';
+import {DecisionLogsCollection, DecisionsCollection, NotesModel, UserModel} from './model-mocks';
 import {
   findDataCarrier,
   findDataChild,
@@ -152,9 +150,9 @@ describe('withResources', () => {
           if (shouldResourcesError) {
             ModelCache.remove(key);
 
-            rej([model, model !== EMPTY_COLLECTION && model !== EMPTY_MODEL ? 404 : null]);
+            rej([model, !model.isEmptyModel ? 404 : null]);
           } else {
-            res([model, model !== EMPTY_COLLECTION && model !== EMPTY_MODEL ? 200 : null]);
+            res([model, !model.isEmptyModel ? 200 : null]);
           }
         });
       });
@@ -645,11 +643,12 @@ describe('withResources', () => {
       await waitsFor(() => dataChild.props.hasLoaded);
       // these are our two critical resources, whose models have been placed in
       // the cache before fetching
-      expect(dataChild.props.decisionsCollection).not.toEqual(EMPTY_COLLECTION);
-      expect(dataChild.props.userModel).not.toEqual(EMPTY_MODEL);
+      expect(dataChild.props.decisionsCollection.isEmptyModel).not.toBeDefined();
+      expect(dataChild.props.userModel.isEmptyModel).not.toBeDefined();
 
       // however, this is a pending resource, so it should not be in the cache
-      expect(dataChild.props.notesModel).toEqual(EMPTY_MODEL);
+      expect(dataChild.props.notesModel.isEmptyModel).toBe(true);
+      expect(dataChild.props.notesModel instanceof NotesModel).toBe(true);
 
       unmountAndClearModelCache();
 
@@ -659,8 +658,10 @@ describe('withResources', () => {
 
       await waitsFor(() => dataChild.props.hasErrored);
 
-      expect(dataChild.props.decisionsCollection).toEqual(EMPTY_COLLECTION);
-      expect(dataChild.props.userModel).toEqual(EMPTY_MODEL);
+      expect(dataChild.props.decisionsCollection.isEmptyModel).toBe(true);
+      expect(dataChild.props.decisionsCollection instanceof DecisionsCollection).toBe(true);
+      expect(dataChild.props.userModel.isEmptyModel).toBe(true);
+      expect(dataChild.props.userModel instanceof UserModel).toBe(true);
       done();
     });
 
@@ -963,7 +964,7 @@ describe('withResources', () => {
       // we have a new model cache key for the dependent model because
       // the value of serialProp has changed. so the cache lookup should
       // again be empty
-      expect(dataChild.props.decisionLogsCollection).toEqual(EMPTY_COLLECTION);
+      expect(dataChild.props.decisionLogsCollection.isEmptyModel).toBe(true);
       done();
     });
   });


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

Changes the empty model types from being a default Schmackbone.Model/Collection instance to being instances of the intended resource model. This allows access to custom model instance methods without being defensive, simplifying code.

```js
props.myModel.myInstanceMethod() // now will never break, regardless of model loading status
```
