### PR TITLE
Remove aggressive caching

### DIFF
--- a/lib/model-cache.js
+++ b/lib/model-cache.js
@@ -97,6 +97,11 @@ export default {
    */
   remove(cacheKey) {
     clearModel(cacheKey);
+  },
+
+  // internal only
+  __removeAll__() {
+    modelCache.forEach((val, key) => clearModel(key));
   }
 };
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -65,7 +65,6 @@ export default (key, Model, options={}) => {
     _promise = new Promise((resolve, reject) => {
       if (!model || options.forceFetch) {
         model = model || new Model(options[getFirstArgPropertyName(Model)], options.options || {});
-        ModelCache.put(key, model, options.component);
 
         if (options.fetch) {
           addToLoadingCache = true;
@@ -73,18 +72,16 @@ export default (key, Model, options={}) => {
           model.fetch({data: options.data, type: options.method}).then(
             ([newModel, json, opts={}]) => {
               delete loadingCache[key];
+              ModelCache.put(key, newModel, options.component);
               resolve([newModel, (opts.response || {}).status]);
             },
             ([newModel, response={}, opts={}]) => {
               delete loadingCache[key];
-
-              // don't cache errored requests
-              ModelCache.remove(key);
-
               reject([newModel, response.status]);
             }
           );
         } else {
+          ModelCache.put(key, model, options.component);
           resolve([model]);
         }
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/model-mocks.js
+++ b/test/model-mocks.js
@@ -1,8 +1,11 @@
 import Schmackbone from 'schmackbone';
 
 export const UserModel = Schmackbone.Model.extend({
+  key: 'user',
+
   initialize(attrs, options={}) {
     this.userId = options.userId;
+    this.fraudLevel = options.fraudLevel;
   },
 
   url() {
@@ -11,18 +14,21 @@ export const UserModel = Schmackbone.Model.extend({
 }, {cacheFields: ['fraudLevel', 'userId', 'id']});
 
 export const AnalystsCollection = Schmackbone.Collection.extend({
+  key: 'analysts',
   url() {
     return '/root/analysts';
   }
 });
 
 export const DecisionsCollection = Schmackbone.Collection.extend({
+  key: 'decisions',
   url() {
     return '/root/decisions';
   }
 }, {cacheFields: ['include_deleted']});
 
 export const NotesModel = Schmackbone.Model.extend({
+  key: 'notes',
   initialize(attributes, options={}) {
     this.userId = options.userId;
   },
@@ -33,6 +39,7 @@ export const NotesModel = Schmackbone.Model.extend({
 }, {cacheFields: ['userId']});
 
 export const SearchQueryModel = Schmackbone.Model.extend({
+  key: 'search',
   initialize(attributes, options={}) {
     this.userId = options.userId;
   },
@@ -45,7 +52,7 @@ export const SearchQueryModel = Schmackbone.Model.extend({
       type: 'POST'
     };
 
-    Schmackbone.Model.prototype.fetch.call(this, options);
+    return Schmackbone.Model.prototype.fetch.call(this, options);
   },
 
   url() {
@@ -54,18 +61,21 @@ export const SearchQueryModel = Schmackbone.Model.extend({
 }, {cacheFields: ['type', 'detailed', 'filter', 'sort', 'limit', 'from']});
 
 export const SignalsCollection = Schmackbone.Collection.extend({
+  key: 'signals',
   url() {
     return '/root/signals';
   }
 });
 
 export const ActionsCollection = Schmackbone.Collection.extend({
+  key: 'actions',
   url() {
     return '/root/actions';
   }
 });
 
 export const DecisionLogsCollection = Schmackbone.Collection.extend({
+  key: 'decisionLogs',
   url() {
     return '/root/decision_logs';
   }
@@ -80,6 +90,7 @@ export const DecisionInstanceModel = Schmackbone.Model.extend(
 export const LabelInstanceModel = Schmackbone.Model.extend({}, {cacheFields: ['userId']});
 
 export const AccountConfigModel = Schmackbone.Model.extend({
+  key: 'accountConfig',
   initialize(attrs, options={}) {
     this.accountId = options.accountId;
   },


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

Following [this fix](https://github.com/noahgrant/resourcerer/pull/74), a subtle bug was exposed with how resourcerer was adding its models to the cache: it would add the new model to the cache as soon as it was requested, and then remove it if errored. There are two issues with this approach now that components can be initially in a loaded state and now that both the HOC and the hook rely on component state instead of reading directly from the cache:

* Components set their initial loading states based on whether the model exists in the cache; with aggressive caching, a component can be mounted and given a `loaded` state before the request returns
* Prefetching would break components' loading states, for the same reason.

## Description of Proposed Changes:  
  - Removes the initial `ModelCache.put` just after requesting and places it in the request success callback
  - Removes the cache removal on error, since it wouldn't exist
 
