### PR TITLE
add default to buildLoadingStates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -173,7 +173,8 @@ export const withResources = (getResources) =>
           ), {}),
           ...buildResourcesLoadingState(
             pendingResources.concat(resourcesToUpdate.filter(withoutPrefetch)),
-            nextProps
+            nextProps,
+            LoadingStates.LOADING
           )
         });
 
@@ -396,7 +397,11 @@ export const useResources = (getResources, props) => {
             }),
         nextLoadingStates = buildResourcesLoadingState(
           pendingResources.concat(resourcesToUpdate.filter(withoutPrefetch)),
-          props
+          props,
+          // subtle bug: at this point in the lifecycle, all resources must go into a LOADING state;
+          // without this argument, anything already cached would go into a LOADED state while their
+          // corresponding model would be the empty model. they must be kept in sync.
+          LoadingStates.LOADING
         );
 
     // first set our updated resources' loading states to LOADING. also, any
@@ -713,14 +718,20 @@ function findCacheKey(resource, getResources, props) {
  *
  * @param {array[]} resources - list of resource config entries for fetching
  * @param {object} props - current component props
+ * @param {LoadingStates} defaultState - state to return if resource already exists in cache;
+ *   in most circumstances, this should be the LOADED state as you might expect. However, when we
+ *   prep resources to be re-fetched, in order to keep the loading state in sync with its model
+ *   state, even a cached resource should be temporarily in a LOADING state (if cached, this will
+ *   be corrected in the next microtask and before the JS stack is completed, so the LOADING state
+ *   should never be shown in the UI, despite render being called multiple times).
  * @return {object} state object with resource state keys as keys and the loading
  *    state as values
  */
-function buildResourcesLoadingState(resources, props) {
+function buildResourcesLoadingState(resources, props, defaultState=LoadingStates.LOADED) {
   return resources.reduce((state, [name, config]) => Object.assign(state, {
     [getResourceState(name)]:
       shouldBypassFetch(props, [name, config]) || getModelFromCache(config, props) ?
-        LoadingStates.LOADED :
+        defaultState :
         (!hasAllDependencies(props, [, config]) ? LoadingStates.PENDING : LoadingStates.LOADING)
   }), {});
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
A subtle bug where a cached resource would have its loading state (`LOADED`) momentarily out of sync with its model state (the previous model). While not present in the UI, render is called 2x before painting, and this can cause errors in components counting on a populated model after a `hasLoaded` check.

## Description of Proposed Changes:  
  -  Add a backup to `buildLoadingStates` function to ensure that all resources go into a `LOADING` state if they're going to be updated, even if they exist in the cache.

