### PR TITLE
move withResources to componentDidUpdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,16 +829,11 @@ ResourcesConfig.set(configObj);
 
 * Does it support async rendering?  
   
-    Short answer: For the `useResources` hook: yes! For the `withResources` HOC, no.
-    
-    Long answer:  
-    
-    The `withResources` HOC still employs one instance of `UNSAFE_componentWillReceiveProps` to set loading states prior to fetching a new resource. The benefit to using cWRP is that it avoids an extra render caused by setting state after an update has happened. The downside is that it prevents `withResources`, for now, from safely using some of React's newer APIs, such as asynchronous rendering with Suspense. Full disclosure: I am sad that `componentWillReceiveProps` has been deprecated, and I would much prefer to keep it and have the React team trust developers not to put side effects in it. But I still think it has an important place in preventing extra renders. [getDerivedStateFromProps](https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops) does not allow you to compare previous to next without doing some state hackery.
+    Yes! `withResources` used to depend on `componentWillReceiveProps`, but as of v0.9 it has been updated to use `componentDidUpdate` instead.
+    The upside is that it now supports async rendering; the downside, however, is that it requires an extra render before updating a resource
+    (since `componentDidUpdate` gets called after `render`, setting any loading states will cause an additional subsequent render).
 
-    The `useResources` React hook, on the other hand, will support async rendering. It also, however requires that extra render that the HOC avoids.
-    
-    In the future, we really have no choice but to migrate `withResources` to use `componentDidUpdate`, which will make it compatible with async rendering but will also have the extra render call.
-
+    `useResources` has always supported async rendering.
         
 * Can the `withResources` HOC be used with both function components and class components?
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ const SPREAD_PROVIDES_CHAR = '_';
  * state that should trigger resource updates. Some things won't need this, ie
  * a url update that passes its query params down as props[queryParamsPropName].
  * But it provides a setResourceState method to wrap any necessary state that
- * may cause a resource update in DataCarrier's componentWillReceiveProps.
+ * may cause a resource update in DataCarrier's componentDidUpdate.
  */
 const resourceState = (Component) =>
   class ResourceStateWrapper extends React.Component {
@@ -55,10 +55,10 @@ const resourceState = (Component) =>
  * The withResources decorator produces a Data Carrier component that handles
  * several different data-related things for a component automatically:
  *
- *   1. it fetches a component's resources in cWM
+ *   1. it fetches a component's resources in cDM
  *   2. it binds schmackboneMixin listeners to all resources
  *   3. it handles whether or not the critical resources for a component have loaded
- *   4. it re-fetches a new resource in cWRP when specified props have changed
+ *   4. it re-fetches a new resource in cDU when specified props have changed
  *   5. it handles resource cache naming for the ModelCache
  *
  * getResources is a function that takes props as an argument and should return
@@ -67,17 +67,6 @@ const resourceState = (Component) =>
  * custom name if passed a modelKey config property), and each map value is a
  * config object that may contain any of the following properties:
  *
- *   * fields {string[]|object[]} - **** DEPRECATED - only use this if you need
- *        to respond to dynamic props that can't be added to a model's static
- *        `cacheFields` property ****
- *        list of property names within props that should trigger a re-fetch
- *        when changed. if a field entry is passed in as an object, it can have
- *        the following properties:
- *          * name {string} (required) - the name of the prop
- *          * cacheIgnore {boolean} if true, the field will still trigger a
- *            refetch, but will not be taken into account for the cache key
- *          * map {function} - when present, return value will be used for the
- *            cache key. takes the prop value and the props object as arguments
  *   * noncritical {boolean} - whether the resource should not be taken into
  *        account when determining the loading state of the component. default
  *        is false
@@ -127,8 +116,8 @@ export const withResources = (getResources) =>
           // this is ultimately just simpler, despite the denormalization
           ...resources.filter(withoutPrefetch).reduce((models, [name, config]) => ({
             ...models,
-            [getResourcePropertyName(name, config.modelKey)]:
-              getModelFromCache(config, this.props) || getEmptyModel(config.modelKey)
+            [getResourcePropertyName(name, config.modelKey)]: getModelFromCache(config) ||
+              getEmptyModel(config.modelKey)
           }), {}),
           ...initialLoadingStates,
           /**
@@ -145,66 +134,65 @@ export const withResources = (getResources) =>
             .filter(not(shouldBypassFetch.bind(null, this.props)));
 
         // fetch models
-        this._fetchResources(resources, this.props);
+        this._fetchResources(resources);
         this._isMounted = true;
 
         this._getBackboneModels = () => this._generateResources()
-            .map(([, config]) => getModelFromCache(config, this.props))
+            .map(([, config]) => getModelFromCache(config))
             .filter(Boolean);
       }
 
-      UNSAFE_componentWillReceiveProps(nextProps) {
+      componentDidUpdate(prevProps) {
         // update models based on new props or new resources
-        var nextResources = this._generateResources(nextProps),
-            pendingResources = nextResources.filter(not(hasAllDependencies.bind(null, nextProps))),
-            resourcesToUpdate = nextResources.filter(hasAllDependencies.bind(null, nextProps))
-                .filter(not(shouldBypassFetch.bind(null, nextProps)))
+        var nextResources = this._generateResources(),
+            pendingResources = nextResources.filter(not(hasAllDependencies.bind(null, this.props)))
+                .filter(([, config]) => hasAllDependencies(prevProps, [, config])),
+            resourcesToUpdate = nextResources.filter(hasAllDependencies.bind(null, this.props))
+                .filter(not(shouldBypassFetch.bind(null, this.props)))
                 .filter(([name, config]) =>
-                  this._hasResourceConfigChanged(name, config, nextProps) ||
-                  !hasAllDependencies(this.props, [, config]));
+                  this._hasResourceConfigChanged(name, config, prevProps) ||
+                  !hasAllDependencies(prevProps, [, config]));
 
         // first set our updated resources' loading states to LOADING. also, any
         // resources that have lost their dependencies should go back to a pending state
         // and their models reverted to the empty models
-        this.setState({
-          ...pendingResources.reduce((memo, [name, {modelKey}]) => Object.assign(
-            memo,
-            {[getResourcePropertyName(name, modelKey)]: getEmptyModel(modelKey)}
-          ), {}),
-          ...buildResourcesLoadingState(
-            pendingResources.concat(resourcesToUpdate.filter(withoutPrefetch)),
-            nextProps,
-            LoadingStates.LOADING
-          )
-        });
+        if (pendingResources.length || resourcesToUpdate.length) {
+          this.setState({
+            ...pendingResources.reduce((memo, [name, config]) => Object.assign(memo, {
+              // if pending resource cache key doesn't change, don't reset it to empty
+              [getResourcePropertyName(name, config.modelKey)]: getModelFromCache(config) ||
+                getEmptyModel(config.modelKey)
+            }), {}),
+            // pending resources should stay in loaded state if their model is still in the cache
+            ...buildResourcesLoadingState(pendingResources, this.props),
+            // but resourcesToUpdate should get set to loading. if in the cache, they'll get reset
+            // to loaded in the resolved fetch's success handler
+            ...buildResourcesLoadingState(
+              resourcesToUpdate.filter(withoutPrefetch),
+              this.props,
+              LoadingStates.LOADING
+            )
+          });
+        }
 
         resourcesToUpdate.forEach(([name, config]) => {
-          var currentConfig = findConfig([name, config], getResources, this.props),
-              currentCacheKey = this._findCurrentCacheKey([name, config]);
+          var previousConfig = findConfig([name, config], getResources, prevProps),
+              previousCacheKey = this._findCurrentCacheKey([name, config], prevProps);
 
           // unregister component from previous models that are getting updated
-          ModelCache.unregister(this, currentCacheKey);
+          ModelCache.unregister(this, previousCacheKey);
 
-          // recaching a model if it newly acquired an id
-          if (!currentConfig.attributes?.id && config.attributes?.id) {
-            ModelCache.put(getCacheKey(config, nextProps), ModelCache.get(currentCacheKey));
-            ModelCache.remove(currentCacheKey);
+          // this is our re-caching: if we already have a new model in the cache that has now been
+          // saved (and thus has a real cache key), move the model to the new cache key and remove
+          // it from the old one. this will save an unnecessary request.
+          if (previousConfig.attributes && !previousConfig.attributes.id && config.attributes?.id) {
+            ModelCache.put(getCacheKey(config), ModelCache.get(previousCacheKey));
+            ModelCache.remove(previousCacheKey);
           }
         });
 
         if (resourcesToUpdate.length) {
-          this._fetchResources(resourcesToUpdate, nextProps);
-        }
-      }
-
-      componentDidUpdate() {
-        var criticalResources = this._generateResources()
-            .filter(withoutPrefetch)
-            .filter(withoutNoncritical);
-
-        if (!this.state.hasInitiallyLoaded &&
-            hasLoaded(getCriticalLoadingStates(this.state, criticalResources))) {
-          this.setState({hasInitiallyLoaded: true});
+          this._fetchResources(resourcesToUpdate);
         }
       }
 
@@ -213,7 +201,7 @@ export const withResources = (getResources) =>
         ModelCache.unregister(this);
       }
 
-      _fetchResources(resources, props) {
+      _fetchResources(resources, props=this.props) {
         return fetchResources(resources, props, {
           component: this,
           isCurrentResource: ([name, config], cacheKey) => this._isMounted && !config.prefetch &&
@@ -221,14 +209,26 @@ export const withResources = (getResources) =>
           setResourceState: props.setResourceState,
           onRequestSuccess: (model, status, [name, config]) => {
             // set loading state _after_ all its dependencies are added
-            this.setState({
-              [getResourcePropertyName(name, config.modelKey)]: model,
-              [getResourceState(name)]: LoadingStates.LOADED,
-              ...(config.status ? {[getResourceStatus(name)]: status} : {})
+            this.setState((state) => {
+              var nextState = {
+                ...state,
+                [getResourceState(name)]: LoadingStates.LOADED,
+                [getResourcePropertyName(name, config.modelKey)]: model,
+                ...(config.status ? {[getResourceStatus(name)]: status} : {})
+              };
+
+              return {
+                ...nextState,
+                // if we haven't already loaded and this response gets us into the loaded state
+                // across our critical resources, set the hasInitiallyLoaded flag
+                ...!this.state.hasInitiallyLoaded &&
+                  hasLoaded(getCriticalLoadingStates(nextState, resources)) ?
+                  {hasInitiallyLoaded: true} : {}
+              };
             });
           },
           onRequestFailure: (model, status, [name, config]) => {
-            // this catch block gets called _only_ for request errors.
+            // this catch block gets called _only_ for request errors
             this.setState({
               [getResourceState(name)]: LoadingStates.ERROR,
               ...(config.status ? {[getResourceStatus(name)]: status} : {})
@@ -246,48 +246,28 @@ export const withResources = (getResources) =>
         return generateResources(getResources, props);
       }
 
-      _findCurrentCacheKey(resource) {
-        return findCacheKey(resource, getResources, this.props);
+      _findCurrentCacheKey(resource, props=this.props) {
+        return findCacheKey(resource, getResources, props);
       }
 
       /**
        * This method determines whether a resource's config has changed between
-       * this.props and nextProps. This can happen in a couple ways:
-       *
-       * 1. (legacy) the config has a `fields` property. In this case, we
-       *    compare props[field] for each fields entry and return true if
-       *    any are different.
-       * 2. we compare cache key strings for this.props/nextProps
+       * this.props and prevProps. We compare cache key strings for this.props/prevProps
        *
        * @param {string} name - resource name
        * @param {object} config - resource config object
-       * @param {object} nextProps - component's nextProps, used to compare
+       * @param {object} prevProps - component's prevProps, used to compare
        *   cache keys with current props
        * @return {boolean} whether a resource's config has changed between
-       *   this.props and nextProps, which will prompt a refetch
+       *   this.props and prevProps, which will prompt a refetch
        */
-      _hasResourceConfigChanged(name, config, nextProps) {
-        var currentCacheKey = this._findCurrentCacheKey([name, config]);
+      _hasResourceConfigChanged(name, config, prevProps) {
+        var currentCacheKey = this._findCurrentCacheKey([name, config]),
+            previousCacheKey = this._findCurrentCacheKey([name, config], prevProps);
 
-        // this will be true if the current resource is a prefetched resource,
+        // currentCacheKey won't exist if the current resource is a prefetched resource,
         // which we don't want to consider for determining a changed config
-        if (!currentCacheKey) {
-          return true;
-        // the `fields` property is a legacy config property, but does allow for
-        // more flexibility on the part of the component in establishing the
-        // cache key. while we migrate existing configs off of `fields`, we
-        // don't consider cache keys if config.fields exists in case there are
-        // discrepancies. TODO(noah): when all models that use `cacheFields` no
-        // longer have `fields` properties, this block can be removed
-        } else if (config.fields) {
-          // for each resource, check whether any prop fields listed in
-          // config.fields have changed
-          return (config.fields || []).filter(
-            (field) => nextProps[field.name || field] !== this.props[field.name || field]
-          ).length;
-        }
-
-        return currentCacheKey !== getCacheKey(config, nextProps);
+        return !currentCacheKey || currentCacheKey !== previousCacheKey;
       }
 
       render() {
@@ -356,7 +336,7 @@ export const useResources = (getResources, props) => {
       // show an empty model as a resource is being requested instead of
       // continuing to show the previous model. on the plus side, setting them
       // as state means we won't need a loading overlay component to do this for us
-      [models, setModels] = useState(modelAggregator(resources.filter(withoutPrefetch), props)),
+      [models, setModels] = useState(modelAggregator(resources.filter(withoutPrefetch))),
 
       isMountedRef = useIsMounted(false),
       // this is used as an identifier to this component instance to register
@@ -392,17 +372,22 @@ export const useResources = (getResources, props) => {
             .filter(([name, config]) => {
               var previousCacheKey = prevPropsRef.current && getPrevCacheKey([name, config]);
 
-              return (!previousCacheKey || previousCacheKey !== getCacheKey(config, props) ||
+              return (!previousCacheKey || previousCacheKey !== getCacheKey(config) ||
                 !hasAllDependencies(prevPropsRef.current, [, config]));
             }),
-        nextLoadingStates = buildResourcesLoadingState(
-          pendingResources.concat(resourcesToUpdate.filter(withoutPrefetch)),
-          props,
-          // subtle bug: at this point in the lifecycle, all resources must go into a LOADING state;
-          // without this argument, anything already cached would go into a LOADED state while their
-          // corresponding model would be the empty model. they must be kept in sync.
-          LoadingStates.LOADING
-        );
+        nextLoadingStates = {
+          // pending resources should stay in loaded state if their model is still in the cache
+          ...buildResourcesLoadingState(pendingResources, props),
+          // but resourcesToUpdate should get set to LOADING. if in the cache, they'll get reset
+          // to loaded in the resolved fetch's success handler. this is necessary due to a subtle
+          // bug: without this last argument, anything already cached would go into a LOADED state
+          // while their corresponding model would be the empty model. they must be kept in sync.
+          ...buildResourcesLoadingState(
+            resourcesToUpdate.filter(withoutPrefetch),
+            props,
+            LoadingStates.LOADING
+          )
+        };
 
     // first set our updated resources' loading states to LOADING. also, any
     // resources that have lost their dependencies should go back to a pending state
@@ -410,17 +395,18 @@ export const useResources = (getResources, props) => {
       loaderDispatch({type: LoadingStates.LOADING, payload: nextLoadingStates});
     }
 
-    // need to remove our model state here because it won't happen after a
-    // request like the others, since no request is being made for pending resources
+    // need to remove our model state here because it won't happen after a request like the others,
+    // since no request is being made for pending resources. note that this will stay as the
+    // requested model if the dependent prop does not affect the cache key
     if (pendingResources.length) {
-      setModels(modelAggregator(pendingResources, props));
+      setModels(modelAggregator(pendingResources));
     }
 
     if (resourcesToUpdate.length) {
       if (prevPropsRef.current) {
         resourcesToUpdate.forEach(([name, config]) => {
           var prevConfig = findConfig([name, config], getResources, prevPropsRef.current),
-              prevCacheKey = getCacheKey(prevConfig, prevPropsRef.current);
+              prevCacheKey = getCacheKey(prevConfig);
 
           // unregister component from previous models that are getting updated
           ModelCache.unregister(componentRef.current, prevCacheKey);
@@ -429,7 +415,7 @@ export const useResources = (getResources, props) => {
           // saved (and thus has a real cache key), move the model to the new cache key and remove
           // it from the old one. this will save an unnecessary request.
           if (prevConfig.attributes && !prevConfig.attributes?.id && config.attributes?.id) {
-            ModelCache.put(getCacheKey(config, props), ModelCache.get(prevCacheKey));
+            ModelCache.put(getCacheKey(config), ModelCache.get(prevCacheKey));
             ModelCache.remove(prevCacheKey);
           }
         });
@@ -446,7 +432,7 @@ export const useResources = (getResources, props) => {
           // does-react-keep-the-order-for-state-updates/48610973#48610973
           ReactDOM.unstable_batchedUpdates(() => {
             if (resources.filter(withoutPrefetch).length) {
-              setModels(modelAggregator(resources.filter(withoutPrefetch), props));
+              setModels(modelAggregator(resources.filter(withoutPrefetch)));
             }
 
             loaderDispatch({
@@ -465,7 +451,7 @@ export const useResources = (getResources, props) => {
           // think it would be preferable to use state (within a separate useEffect) to determine
           // which models get listened to. but as mentioned, that would require the effect to depend
           // on cache keys, which are dynamic, and effects can't have dynamic dependencies right now
-          let listenedModels = resources.map(([, config]) => getModelFromCache(config, props))
+          let listenedModels = resources.map(([, config]) => getModelFromCache(config))
               .filter(Boolean);
 
           // remove previous listeners and attach new ones
@@ -500,7 +486,7 @@ export const useResources = (getResources, props) => {
       // use _current_ props when getting the models here, because if any have changed over the
       // lifecycle of the component then they should have already had listeners removed. this only
       // removes listeners from the 'last' batch before unmounting
-      resources.map(([, config]) => getModelFromCache(config, currentPropsRef.current))
+      resources.map(([, config]) => getModelFromCache(config))
           .filter(Boolean)
           .concat(bypassedModels)
           .forEach((model) => model.off('all', forceUpdate, model));
@@ -628,44 +614,26 @@ function getEmptyModel(modelKey) {
 
 /**
  * Calculates a cache key for the resource depending on the base resource type
- * key and the truthy parameter values. Parameter values are calculated in one
- * of two ways:
+ * key and the truthy parameter values. Parameter values are calculated in via
+ * the constructor's static `cacheFields` array:
  *
- * * Default: Values are taken from props properties listed in the `fields`
- *   array. Fields passed in as objects are ignored from the key if they have a
- *   `cacheIgnore` property. ** DEPRECATED AND NOT SUPPORTED WITH useResources **
- * * V2, when the model's constructor has a static `cacheFields` array: values
- *   are taken directly from the config object as opposed to props, in the
- *   following order: `options` object, `attributes` object, `data` object.
- *   Field keys are included in this method, which is why it is preferred.
- *   `cacheFields` entries can be functions, too, which take the `data` object
- *   as a parameter and return a key/value object that gets flattened to a piece
- *   of the cache key.
+ *   `cacheFields` values are taken directly from the config object as opposed
+ *   to props, in the following order: `options` object, `attributes` object,
+ *   `data` object. Field keys are included in this method, which is why it is
+ *   preferred. `cacheFields` entries can be functions, too, which take the
+ *   `data` object as a parameter and return a key/value object that gets
+ *   flattened to a piece of the cache key.
  *
  * @param {object} config - resource config object (destructured)
- * @param {object} props - component props
  * @return {string} cache key
  */
-export function getCacheKey({modelKey, fields=[], data={}, options={}, attributes={}}, props={}) {
-  if (!(ModelMap[modelKey] || {}).cacheFields) {
-    // this is the default cache key generation, which will be used if no static `cacheFields`
-    // property exists on the model. it does not use add field keys to the cache key
-    fields = (Array.isArray(fields) ? fields : [fields])
-        .filter((field) => !field.cacheIgnore)
-        .map((field) => typeof field.map === 'function' ?
-          field.map(props[field.name], props) : props[field.name || field])
-        .filter((x) => x);
-  } else {
-    let toKeyValString = ([key, val]) => val ? `${key}=${val}` : '';
-
-    // cache key generation v2: includes field keys as specified in the `cacheFields`
-    // static property on the model constructor
-    fields = ModelMap[modelKey].cacheFields.map(
-      (key) => typeof key === 'function' ?
-        Object.entries(key(data)).map(toKeyValString).join('_') :
-        toKeyValString([key, options[key] || attributes[key] || data[key]])
-    ).filter((x) => x);
-  }
+export function getCacheKey({modelKey, data={}, options={}, attributes={}}) {
+  var toKeyValString = ([key, val]) => val ? `${key}=${val}` : '',
+      fields = (ModelMap[modelKey]?.cacheFields || []).map(
+        (key) => typeof key === 'function' ?
+          Object.entries(key(data)).map(toKeyValString).join('_') :
+          toKeyValString([key, options[key] || attributes[key] || data[key]])
+      ).filter((x) => x);
 
   return `${modelKey || ''}${fields.sort().join('_')}`;
 }
@@ -690,7 +658,7 @@ function findConfig([name, {prefetch}], getResources, props) {
 }
 
 /**
- * When using cache key v2 generation, we no longer use props directly, which
+ * Our cache key generation no longer uses props directly, which
  * makes comparing current/next resources more difficult (ie, we can't just
  * compare `getCacheKey(config, this.props)` and `getCacheKey(config, nextProps)`)
  * directly because `config` itself is determined from props. However,
@@ -707,7 +675,7 @@ function findConfig([name, {prefetch}], getResources, props) {
  *   prefetch, if applicable
  */
 function findCacheKey(resource, getResources, props) {
-  return getCacheKey(findConfig(resource, getResources, props), props) || '';
+  return getCacheKey(findConfig(resource, getResources, props)) || '';
 }
 
 /**
@@ -730,7 +698,7 @@ function findCacheKey(resource, getResources, props) {
 function buildResourcesLoadingState(resources, props, defaultState=LoadingStates.LOADED) {
   return resources.reduce((state, [name, config]) => Object.assign(state, {
     [getResourceState(name)]:
-      shouldBypassFetch(props, [name, config]) || getModelFromCache(config, props) ?
+      shouldBypassFetch(props, [name, config]) || getModelFromCache(config) ?
         defaultState :
         (!hasAllDependencies(props, [, config]) ? LoadingStates.PENDING : LoadingStates.LOADING)
   }), {});
@@ -884,15 +852,14 @@ function getCriticalLoadingStates(loadingStates, resources) {
  * empty model if one does not exist.
  *
  * @param {array[]} resources - list of resource config entries
- * @param {object} props - current component props
  * @return {function} function that can be passed to a state-setting function
  *   that returns models keyed by name
  */
-function modelAggregator(resources, props) {
+function modelAggregator(resources) {
   return (models={}) => ({
     ...models,
     ...resources.reduce((memo, [name, config]) => Object.assign(memo, {
-      [getResourcePropertyName(name, config.modelKey)]: getModelFromCache(config, props) ||
+      [getResourcePropertyName(name, config.modelKey)]: getModelFromCache(config) ||
         getEmptyModel(config.modelKey)
     }), {})
   });
@@ -1010,11 +977,8 @@ function fetchResources(resources, props, {
     // nice visual for this promise chain: http://tinyurl.com/y6wt47b6
     resources.map(([name, config]) => {
       var {data, modelKey, provides={}, ...rest} = config,
-          // unless this is a prefetched resource, resourceProps will just be props
-          resourceProps = {...props, ...(rest.prefetch || {})},
-          cacheKey = getCacheKey(config, resourceProps),
-          shouldMeasure = shouldMeasureRequest(modelKey, config) &&
-            !getModelFromCache(config, resourceProps);
+          cacheKey = getCacheKey(config),
+          shouldMeasure = shouldMeasureRequest(modelKey, config) && !getModelFromCache(config);
 
       if (shouldMeasure) {
         window.performance.mark(name);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

* Updates `withResources` to not use the deprecated `unsafe_componentWillReceiveProps` method.

* Removes the deprecated `fields` config option (only used in `withResources`) to generate the cache key. It now only uses the static `cacheFields` property.
