### PR TITLE
schmackbone 2.0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,7 +14,7 @@
   ],
   "plugins": [
     "@babel/plugin-transform-runtime",
-    ["@babel/proposal-decorators", {"legacy": true}]
-  ],
-  "ignore": ["**/node_modules/**"]
+    ["@babel/proposal-decorators", {"legacy": true}],
+    "@babel/plugin-proposal-class-properties"
+  ]
 }

--- a/ADVANCED_TOPICS.md
+++ b/ADVANCED_TOPICS.md
@@ -106,7 +106,7 @@ You may find, at some point in your application, that you have a `PUT` endpoint 
 
 ```js
 // resources_conifg.js
-import {ResourceKeys, UnfetchedResources} from 'resourcerer/config';
+import {ResourceKeys, UnfetchedResources} from 'resourcerer';
 
 ResourceKeys.add({
   ACCOUNT: 'account',

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ export default class TodosCollection extends Collection {
 
 ```js
 // js/core/resourcerer-config.js
-import {ModelMap} from 'resourcerer/config';
+import {ModelMap} from 'resourcerer';
 import TodosCollection from 'js/models/todos-collection';
 
 // choose any string as its key, which becomes its ResourceKey
@@ -215,7 +215,7 @@ from? From the ModelMap in the config file we added to earlier!
 
 ```js
 // js/core/resourcerer-config.js
-import {ModelMap} from 'resourcerer/config';
+import {ModelMap} from 'resourcerer';
 import TodosCollection from 'js/models/todos-collection';
 
 // after adding this key, resourcerer will add an identical key to the `ResourceKeys` object with a
@@ -266,8 +266,7 @@ In this case, `isLoading` , et al, are only representative of `todosLoadingState
 Here’s how might use that to our advantage in `MyClassWithTodosAndAUsers` :
 
 ```jsx
-// pure functions that accept loading states as arguments
-import ResourcererUtils from 'resourcerer/utils';
+import * as resourcerer from 'resourcerer';
 
 function MyClassWithTodosAndAUsers(props) {
   var {
@@ -300,7 +299,8 @@ function MyClassWithTodosAndAUsers(props) {
         <ul>
           {todosCollection.map((todoModel) => (
             <li key={todoModel.id}>
-              {ResourcererUtils.hasLoaded(usersLoadingState) ?
+              // pure function that accepts loading states as arguments
+              {resourcerer.hasLoaded(usersLoadingState) ?
                 getUserName(todoModel.get('userId')) :
                 // if you're anti-loader, you could opt to render nothing and have the
                 // user name simply appear in place after loading
@@ -333,7 +333,7 @@ Let's say we wanted to request not the entire users collection, but just a speci
 
 ```js
 // js/core/resourcerer-config.js
-import {ModelMap} from 'resourcerer/config';
+import {ModelMap} from 'resourcerer';
 import TodosCollection from 'js/models/todos-collection';
 import UserModel from 'js/models/user-model';
 
@@ -524,7 +524,7 @@ As alluded to in the [Other Props](#other-props-returned-from-the-hookpassed-fro
 
 - De-prioritize fetching the resource until after all critical resources have been fetched
 - Remove the resource from consideration within the component-wide loading states (`hasLoaded`, `isLoading`, `hasErrored`), giving us the ability to render without waiting on those resources
-- Can set our own UI logic around displaying noncritical data based on their individual loading states, ie `usersLoadingState`, which can be passed to the pure helper methods, `hasLoaded`, `hasErrored`, and `isLoading` from `resourcerer/utils`.
+- Can set our own UI logic around displaying noncritical data based on their individual loading states, ie `usersLoadingState`, which can be passed to the pure helper methods, `hasLoaded`, `hasErrored`, and `isLoading` from `resourcerer`.
   
   
 
@@ -778,7 +778,7 @@ When the static `measure` property is/returns true, `resourcerer` will record th
 The same config file used to add to `ResourceKeys` and `ModelMap` also allows you to set custom configuration properties for your own application:
 
 ```js
-import {ResourcesConfig} from 'resourcerer/config';
+import {ResourcesConfig} from 'resourcerer';
 
 ResourcesConfig.set(configObj);
 ```

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -28,8 +28,11 @@ module.exports = (config) => {
       module: {
         rules: [{
           test: /\.jsx?$/,
-          exclude: /node_modules/,
-          use: {loader: 'babel-loader?cacheDirectory=true'}
+          exclude: /node_modules\/(?!(schmackbone)\/).*/,
+          use: {
+            loader: 'babel-loader?cacheDirectory=true',
+            options: {configFile: './.babelrc'}
+          }
         }]
       }
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
 import {camelize, noOp} from './utils';
 import React from 'react';
-import Schmackbone from 'schmackbone';
+import {setAjaxPrefilter} from 'schmackbone';
 
 /**
  * This module contains all the required setup for implementing withResources
@@ -26,7 +26,7 @@ export const ResourceKeys = {
 };
 
 /**
- * ModelMap {{string: Schmackbone.Model|Schmackbone.Collection}}: an object that
+ * ModelMap {{string: Model|Collection}}: an object that
  *   should link the key established in ResourceKeys to Model/Collection
  *   constructors, ie: `[ResourceKeys.USER]: UserModel`. Entries in ResourceKeys
  *   and ModelMap for a resource are required in to use a resource with
@@ -92,8 +92,8 @@ export const ResourcesConfig = {
   /** {function}: Hook to send errors to a logging service. */
   log: noOp,
   /**
-   * {function}: This is a facade for Schmackbone's .ajaxFilter. See documentation for usage at:
-   *     https://github.com/noahgrant/schmackbone#backboneajaxprefilter
+   * {function}: This is a facade for Schmackbone's .setAjaxFilter. See documentation for usage at:
+   *     https://github.com/noahgrant/schmackbone#setajaxprefilter
    */
   prefilter: noOp,
   /**
@@ -111,7 +111,7 @@ export const ResourcesConfig = {
    */
   set(config) {
     if (config.prefilter) {
-      Schmackbone.ajaxPrefilter = config.prefilter;
+      setAjaxPrefilter(config.prefilter);
     }
 
     return Object.assign(this, config);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+import {Collection, Model} from 'schmackbone';
 import {hasErrored, hasLoaded, isLoading, pick} from './utils';
 import {ModelMap, ResourceKeys, ResourcesConfig, UnfetchedResources} from './config';
 import React, {useEffect, useReducer, useRef, useState} from 'react';
@@ -7,7 +8,6 @@ import {LoadingStates} from './constants';
 import ModelCache from './model-cache';
 import ReactDOM from 'react-dom';
 import request from './request';
-import Schmackbone from 'schmackbone';
 import schmackboneMixin from './schmackbone-mixin';
 
 const SPREAD_PROVIDES_CHAR = '_';
@@ -581,7 +581,7 @@ function getResourceStatus(name) {
 function getResourcePropertyName(baseName, modelKey) {
   var Constructor = ModelMap[modelKey];
 
-  return Constructor.prototype instanceof Schmackbone.Collection ? `${baseName}Collection` :
+  return Constructor.prototype instanceof Collection ? `${baseName}Collection` :
     `${baseName}Model`;
 }
 
@@ -592,11 +592,11 @@ function getResourcePropertyName(baseName, modelKey) {
  * the model associated with the modelKey and returns it.
  *
  * @param {string} modelKey - resource type key
- * @return {Schmackbone.Model|Schmackbone.Collection} frozen empty model or collection instance
+ * @return {Model|Collection} frozen empty model or collection instance
  */
 function getEmptyModel(modelKey) {
-  var Model = typeof ModelMap[modelKey] === 'function' ? ModelMap[modelKey] : Schmackbone.Model,
-      emptyInstance = new Model(),
+  var Model_ = typeof ModelMap[modelKey] === 'function' ? ModelMap[modelKey] : Model,
+      emptyInstance = new Model_(),
       FROZEN_EMPTY_MODEL;
 
   // flag to differentiate between other model instances that happen to be empty
@@ -722,7 +722,7 @@ function hasAllDependencies(props, [, {dependsOn}]) {
  * @param {string[]|object[]} fields - list of property names whose values determine
  *    which flavor of resource is requested
  * @param {object} props - current component props
- * @return {Schmackbone.Model|Schmackbone.Collection?} model from the cache
+ * @return {Model|Collection?} model from the cache
  */
 function getModelFromCache(...args) {
   return ModelCache.get(getCacheKey(...args));
@@ -1051,4 +1051,4 @@ function fetchResources(resources, props, {
 }
 
 export {default as prefetch} from './prefetch';
-export {Model, Collection} from 'schmackbone';
+export {Model, Collection};

--- a/lib/model-cache.js
+++ b/lib/model-cache.js
@@ -35,7 +35,7 @@ export default {
    * an additional component is registered to the model.
    *
    * @param {string} cacheKey - The cache key of the model to be removed.
-   * @param {Backbone.Model | Backbone.Collection} model - model to be cached
+   * @param {Model | Collection} model - model to be cached
    * @param {React.Component} component - component to register to model in the component manifest
    */
   put(cacheKey, model, component) {

--- a/lib/prefetch.js
+++ b/lib/prefetch.js
@@ -1,7 +1,7 @@
 import {ModelMap, ResourceKeys} from './config';
 import {noOp, once} from './utils';
 
-import {getCacheKey} from './index';
+import {getCacheKey} from './resourcerer';
 import request from './request';
 
 // prevents api request bursts based on quick swipes

--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -1049,6 +1049,3 @@ function fetchResources(resources, props, {
     })
   );
 }
-
-export {default as prefetch} from './prefetch';
-export {Model, Collection};

--- a/lib/schmackbone-mixin.js
+++ b/lib/schmackbone-mixin.js
@@ -1,5 +1,5 @@
+import {Collection, Model} from 'schmackbone';
 import {mixin} from './utils';
-import Schmackbone from 'schmackbone';
 
 /**
  * This mixin force updates a React component when its associated Backbone models
@@ -74,8 +74,8 @@ export default mixin({
  */
 function detectBackboneModels(component) {
   return Object.values(component).filter((value) =>
-    value instanceof Schmackbone.Model ||
-    value instanceof Schmackbone.Collection);
+    value instanceof Model ||
+    value instanceof Collection);
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1420,13 +1420,154 @@
       }
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
-      "integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
+      "integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.10.4",
+        "@babel/helper-create-class-features-plugin": "^7.12.1",
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
+          "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.5",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-create-class-features-plugin": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
+          "integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-member-expression-to-functions": "^7.12.1",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.12.1",
+            "@babel/helper-split-export-declaration": "^7.10.4"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.12.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+          "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.7"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
+          "integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.12.1",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/traverse": "^7.12.5",
+            "@babel/types": "^7.12.5"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+          "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.11.0"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.12.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
+          "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.12.7",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+          "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/parser": "^7.12.7",
+            "@babel/types": "^7.12.7"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.12.9",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
+          "integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.12.5",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/parser": "^7.12.7",
+            "@babel/types": "^7.12.7",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/types": {
+          "version": "7.12.7",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
+          "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/plugin-proposal-decorators": {
@@ -3255,7 +3396,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -3472,7 +3614,8 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -6363,11 +6506,6 @@
       "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
       "dev": true
     },
-    "qs": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
-    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -6744,33 +6882,6 @@
         "ajv-keywords": "^3.1.0"
       }
     },
-    "schmackbone": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/schmackbone/-/schmackbone-1.5.1.tgz",
-      "integrity": "sha512-FCK1Yib6nUZ+vc+wd2bXEB8OGwJ9uGXF9XSQ9SeOLWO8Qne9hblp6GLgmNfXKnA21cvzhgHjhtBFw9KpT2mAHA==",
-      "requires": {
-        "qs": "^6.5.2",
-        "terser": "^4.6.12",
-        "underscore": ">=1.8.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "terser": {
-          "version": "4.6.13",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
-          "integrity": "sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==",
-          "requires": {
-            "commander": "^2.20.0",
-            "source-map": "~0.6.1",
-            "source-map-support": "~0.5.12"
-          }
-        }
-      }
-    },
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
@@ -7093,6 +7204,7 @@
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
       "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -7101,7 +7213,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2513,6 +2513,7 @@
       "version": "7.11.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.0.tgz",
       "integrity": "sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -2520,7 +2521,8 @@
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
         }
       }
     },
@@ -6506,6 +6508,11 @@
       "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
       "dev": true
     },
+    "qs": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -6880,6 +6887,15 @@
         "ajv": "^6.1.0",
         "ajv-errors": "^1.0.0",
         "ajv-keywords": "^3.1.0"
+      }
+    },
+    "schmackbone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/schmackbone/-/schmackbone-2.0.0.tgz",
+      "integrity": "sha512-OcDWA/dFX62cPnQcHryPSoHZtZzuYQMQaGYQEyT+2K8Gz7p3GUGGwF7iBv8VlyKTuwR4XytiigIM8u7wvJRQOw==",
+      "requires": {
+        "qs": "^6.5.2",
+        "underscore": "^1.11.0"
       }
     },
     "semver": {
@@ -7685,9 +7701,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
+      "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "repository": "github.com/SiftScience/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.10.5",
+    "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/plugin-proposal-decorators": "^7.10.5",
     "@babel/plugin-transform-runtime": "^7.10.5",
     "@babel/preset-env": "^7.10.4",
@@ -45,7 +46,7 @@
     "@babel/runtime": "^7.10.5",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
-    "schmackbone": "^1.5.1",
+    "schmackbone": "^2.0.0",
     "underscore": "^1.8.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "resourcerer",
   "version": "0.10.0",
-  "repository": "github.com/SiftScience/resourcerer",
+  "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [
     "declarative data-fetching framework",
@@ -16,10 +16,9 @@
   "scripts": {
     "checks": "npm test && npm run lint",
     "lint": "eslint lib/*.js* test/*.js*",
-    "prepublishOnly": "babel lib -d ./ && babel test/test-utils.js -o ./test-utils.js",
     "test": "NODE_ENV=test && karma start"
   },
-  "author": "",
+  "module": "index.js",
   "devDependencies": {
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.10.5",
@@ -43,11 +42,9 @@
     "webpack": "^4.29.6"
   },
   "dependencies": {
-    "@babel/runtime": "^7.10.5",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
-    "schmackbone": "^2.0.0",
-    "underscore": "^1.8.3"
+    "schmackbone": "^2.0.0"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/test/config.js
+++ b/test/config.js
@@ -1,9 +1,9 @@
 import * as Config from '../lib/config';
+import * as Schmackbone from 'schmackbone';
 import {noOp} from '../lib/utils';
-import Schmackbone from 'schmackbone';
 
-const TestModel = Schmackbone.Model.extend();
-const TestModel2 = Schmackbone.Model.extend();
+class TestModel extends Schmackbone.Model {}
+class TestModel2 extends Schmackbone.Model {}
 
 /* eslint-disable max-nested-callbacks */
 describe('Config', () => {
@@ -89,8 +89,6 @@ describe('Config', () => {
       expect(Config.ResourcesConfig.prefilter).toEqual(noOp);
       expect(Config.ResourcesConfig.track).toEqual(noOp);
       expect(Config.ResourcesConfig.queryParamsPropName).toEqual('urlParams');
-      // default is the identity fn
-      expect(Schmackbone.ajaxPrefilter('foo')).toEqual('foo');
 
       Config.ResourcesConfig.set({
         cacheGracePeriod: 300000,
@@ -105,7 +103,6 @@ describe('Config', () => {
       expect(Config.ResourcesConfig.prefilter).toEqual(prefilterSpy);
       expect(Config.ResourcesConfig.track).toEqual(trackSpy);
       expect(Config.ResourcesConfig.queryParamsPropName).toEqual('queryPs');
-      expect(Schmackbone.ajaxPrefilter).toEqual(prefilterSpy);
 
       Config.ResourcesConfig.set({
         cacheGracePeriod: 120000,
@@ -114,7 +111,6 @@ describe('Config', () => {
         track: noOp,
         queryParamsPropName: 'queryParamsPropName'
       });
-      Schmackbone.ajaxPrefilter = (x) => x;
     });
   });
 });

--- a/test/model-mocks.js
+++ b/test/model-mocks.js
@@ -1,48 +1,58 @@
-import Schmackbone from 'schmackbone';
+import {Collection, Model} from 'schmackbone';
 
-export const UserModel = Schmackbone.Model.extend({
-  key: 'user',
+export class UserModel extends Model {
+  key = 'user'
 
   initialize(attrs, options={}) {
     this.userId = options.userId;
     this.fraudLevel = options.fraudLevel;
-  },
+  }
 
   url() {
     return `/root/users/${this.userId}`;
   }
-}, {cacheFields: ['fraudLevel', 'userId', 'id']});
 
-export const AnalystsCollection = Schmackbone.Collection.extend({
-  key: 'analysts',
+  static cacheFields = ['fraudLevel', 'userId', 'id']
+}
+
+export class AnalystsCollection extends Collection {
+  key = 'analysts'
+
   url() {
     return '/root/analysts';
   }
-});
+}
 
-export const DecisionsCollection = Schmackbone.Collection.extend({
-  key: 'decisions',
+export class DecisionsCollection extends Collection {
+  key = 'decisions'
+
   url() {
     return '/root/decisions';
   }
-}, {cacheFields: ['include_deleted']});
 
-export const NotesModel = Schmackbone.Model.extend({
-  key: 'notes',
+  static cacheFields = ['include_deleted']
+}
+
+export class NotesModel extends Model {
+  key = 'notes'
+
   initialize(attributes, options={}) {
     this.userId = options.userId;
-  },
+  }
 
   url() {
     return `/root/${this.userId}/notes`;
   }
-}, {cacheFields: ['userId']});
 
-export const SearchQueryModel = Schmackbone.Model.extend({
-  key: 'search',
+  static cacheFields = ['userId']
+}
+
+export class SearchQueryModel extends Model {
+  key = 'search'
+
   initialize(attributes, options={}) {
     this.userId = options.userId;
-  },
+  }
 
   fetch(options={}) {
     options = {
@@ -52,50 +62,59 @@ export const SearchQueryModel = Schmackbone.Model.extend({
       type: 'POST'
     };
 
-    return Schmackbone.Model.prototype.fetch.call(this, options);
-  },
+    return Model.prototype.fetch.call(this, options);
+  }
 
   url() {
     return '/root/search';
   }
-}, {cacheFields: ['type', 'detailed', 'filter', 'sort', 'limit', 'from']});
 
-export const SignalsCollection = Schmackbone.Collection.extend({
-  key: 'signals',
+  static cacheFields = ['type', 'detailed', 'filter', 'sort', 'limit', 'from']
+}
+
+export class SignalsCollection extends Collection {
+  key = 'signals'
+
   url() {
     return '/root/signals';
   }
-});
+}
 
-export const ActionsCollection = Schmackbone.Collection.extend({
-  key: 'actions',
+export class ActionsCollection extends Collection {
+  key = 'actions'
+
   url() {
     return '/root/actions';
   }
-});
+}
 
-export const DecisionLogsCollection = Schmackbone.Collection.extend({
-  key: 'decisionLogs',
+export class DecisionLogsCollection extends Collection {
+  key = 'decisionLogs'
+
   url() {
     return '/root/decision_logs';
   }
-}, {cacheFields: ['logs']});
+
+  static cacheFields = ['logs']
+}
 
 // next three are unfetched resources
-export const DecisionInstanceModel = Schmackbone.Model.extend(
-  {},
-  {cacheFields: ['entityType', 'entityId']}
-);
+export class DecisionInstanceModel extends Model {
+  static cacheFields = ['entityType', 'entityId']
+}
 
-export const LabelInstanceModel = Schmackbone.Model.extend({}, {cacheFields: ['userId']});
+export class LabelInstanceModel extends Model {
+  static cacheFields = ['userId']
+}
 
-export const AccountConfigModel = Schmackbone.Model.extend({
-  key: 'accountConfig',
+export class AccountConfigModel extends Model {
+  key = 'accountConfig'
+
   initialize(attrs, options={}) {
     this.accountId = options.accountId;
-  },
+  }
 
   url() {
     return `/root/accounts/${this.accountId}/config`;
   }
-});
+}

--- a/test/prefetch.js
+++ b/test/prefetch.js
@@ -1,9 +1,9 @@
 import * as Request from '../lib/request';
 import {DecisionsCollection, UserModel} from './model-mocks';
 
+import {Collection} from 'schmackbone';
 import prefetch from '../lib/prefetch';
 import ReactDOM from 'react-dom';
-import Schmackbone from 'schmackbone';
 
 const jasmineNode = document.createElement('div');
 const getResources = (props, {DECISIONS, USER}) => ({
@@ -19,7 +19,7 @@ const dummyEvt = {target: jasmineNode};
 describe('prefetch', () => {
   beforeEach(() => {
     document.body.appendChild(jasmineNode);
-    spyOn(Request, 'default').and.callFake(() => Promise.resolve(new Schmackbone.Collection([])));
+    spyOn(Request, 'default').and.callFake(() => Promise.resolve(new Collection([])));
 
     jasmine.clock().install();
   });

--- a/test/request.js
+++ b/test/request.js
@@ -1,7 +1,7 @@
+import * as Schmackbone from 'schmackbone';
 import request, {existsInCache, getFromCache} from '../lib/request';
 
 import ModelCache from '../lib/model-cache';
-import Schmackbone from 'schmackbone';
 import {waitsFor} from './test-utils';
 
 const component = {};

--- a/test/schmackbone-mixin.js
+++ b/test/schmackbone-mixin.js
@@ -1,12 +1,12 @@
+import {Collection, Model} from 'schmackbone';
 import React from 'react';
-import Schmackbone from 'schmackbone';
 import schmackboneMixin from '../lib/schmackbone-mixin';
 
 describe('SchmackboneMixin', () => {
   var dummyComponent,
-      model1 = new Schmackbone.Model(),
-      model2 = new Schmackbone.Collection(),
-      model3 = new Schmackbone.Model(),
+      model1 = new Model(),
+      model2 = new Collection(),
+      model3 = new Model(),
       forceUpdateSpy;
 
   beforeEach(() => {

--- a/test/use-resources.jsx
+++ b/test/use-resources.jsx
@@ -1,4 +1,5 @@
 import * as Request from '../lib/request';
+import * as Schmackbone from 'schmackbone';
 
 import {
   AnalystsCollection,
@@ -16,7 +17,6 @@ import {LoadingStates} from '../lib/constants';
 import ModelCache from '../lib/model-cache';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Schmackbone from 'schmackbone';
 import {waitsFor} from './test-utils';
 
 var measure;
@@ -634,12 +634,12 @@ describe('useResources', () => {
 
       expect(() => decisionsCollection.models.push({frontend: 'farmers'})).toThrow();
       expect(decisionsCollection.length).toEqual(0);
-      decisionsCollection.add({frontend: 'farmers'});
+      expect(() => decisionsCollection.add({frontend: 'farmers'})).toThrow();
       expect(decisionsCollection.length).toEqual(0);
 
       expect(() => userModel.attributes.frontend = 'farmers').toThrow();
       expect(userModel.attributes.frontend).not.toBeDefined();
-      userModel.set('frontend', 'farmers');
+      expect(() => userModel.set('frontend', 'farmers')).toThrow();
       expect(userModel.attributes.frontend).not.toBeDefined();
 
       done();

--- a/test/use-resources.jsx
+++ b/test/use-resources.jsx
@@ -8,7 +8,7 @@ import {
   NotesModel,
   UserModel
 } from './model-mocks';
-import {getCacheKey, useResources} from '../lib/index';
+import {getCacheKey, useResources} from '../lib/resourcerer';
 import {hasErrored, hasLoaded, isLoading, isPending, noOp} from '../lib/utils';
 import {ModelMap, ResourceKeys, ResourcesConfig} from '../lib/config';
 

--- a/test/with-resources.jsx
+++ b/test/with-resources.jsx
@@ -1,4 +1,5 @@
 import * as Request from '../lib/request';
+import * as Schmackbone from 'schmackbone';
 
 import {
   prefetch as _prefetch,
@@ -34,7 +35,6 @@ import ModelCache from '../lib/model-cache';
 import prefetch from '../lib/prefetch';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Schmackbone from 'schmackbone';
 
 var measure,
     causeLogicError;
@@ -601,12 +601,12 @@ describe('withResources', () => {
 
       expect(() => decisionsCollection.models.push({frontend: 'farmers'})).toThrow();
       expect(decisionsCollection.length).toEqual(0);
-      decisionsCollection.add({frontend: 'farmers'});
+      expect(() => decisionsCollection.add({frontend: 'farmers'})).toThrow();
       expect(decisionsCollection.length).toEqual(0);
 
       expect(() => userModel.attributes.frontend = 'farmers').toThrow();
       expect(userModel.attributes.frontend).not.toBeDefined();
-      userModel.set('frontend', 'farmers');
+      expect(() => userModel.set('frontend', 'farmers')).toThrow();
       expect(userModel.attributes.frontend).not.toBeDefined();
 
       done();

--- a/test/with-resources.jsx
+++ b/test/with-resources.jsx
@@ -2,13 +2,6 @@ import * as Request from '../lib/request';
 import * as Schmackbone from 'schmackbone';
 
 import {
-  prefetch as _prefetch,
-  Collection,
-  getCacheKey,
-  Model,
-  withResources
-} from '../lib/index';
-import {
   AnalystsCollection,
   DecisionLogsCollection,
   DecisionsCollection,
@@ -21,6 +14,7 @@ import {
   getRenderedResourceComponents,
   waitsFor
 } from './test-utils';
+import {getCacheKey, withResources} from '../lib/resourcerer';
 import {hasErrored, hasLoaded, isLoading, isPending, noOp} from '../lib/utils';
 import {ModelMap, ResourceKeys, ResourcesConfig} from '../lib/config';
 import {
@@ -32,7 +26,6 @@ import {
 import ErrorBoundary from '../lib/error-boundary';
 import {LoadingStates} from '../lib/constants';
 import ModelCache from '../lib/model-cache';
-import prefetch from '../lib/prefetch';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -1302,12 +1295,6 @@ describe('withResources', () => {
         done();
       });
     });
-  });
-
-  it('exports Model and Collection constructors directly', () => {
-    expect(_prefetch).toEqual(prefetch);
-    expect(Model).toEqual(Schmackbone.Model);
-    expect(Collection).toEqual(Schmackbone.Collection);
   });
 
   it('recaches models that get an id for the first time', async() => {


### PR DESCRIPTION
## Description of Proposed Changes:  
  Adds support for the lighter, modularized Schmackbone:
    * switch imports to ES6 
    * migrate test models to classes
    * use new `setAjaxPrefilter` config method instead of setting it directly
    * babelify some node_modules, with added class properties syntax
    
