### PR TITLE
unfreeze empty model instances

### DIFF
--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -592,22 +592,21 @@ function getResourcePropertyName(baseName, modelKey) {
  * the model associated with the modelKey and returns it.
  *
  * @param {string} modelKey - resource type key
- * @return {Model|Collection} frozen empty model or collection instance
+ * @return {Model|Collection} empty model or collection instance with frozen
+ *   atributes or models, respectively
  */
 function getEmptyModel(modelKey) {
   var Model_ = typeof ModelMap[modelKey] === 'function' ? ModelMap[modelKey] : Model,
-      emptyInstance = new Model_(),
-      FROZEN_EMPTY_MODEL;
+      emptyInstance = new Model_();
 
   // flag to differentiate between other model instances that happen to be empty
   emptyInstance.isEmptyModel = true;
-  FROZEN_EMPTY_MODEL = Object.freeze(emptyInstance);
 
   // ensure that no resourcerer client can modify empty model's data
-  Object.freeze(FROZEN_EMPTY_MODEL.attributes);
-  Object.freeze(FROZEN_EMPTY_MODEL.models);
+  Object.freeze(emptyInstance.attributes);
+  Object.freeze(emptyInstance.models);
 
-  return FROZEN_EMPTY_MODEL;
+  return emptyInstance;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/use-resources.jsx
+++ b/test/use-resources.jsx
@@ -627,10 +627,10 @@ describe('useResources', () => {
       // we know these are the empty models from the previous test
       ({decisionsCollection, userModel} = dataChild.props);
 
-      expect(() => decisionsCollection.frontend = 'farmers').toThrow();
-      expect(decisionsCollection.frontend).not.toBeDefined();
-      expect(() => userModel.frontend = 'farmers').toThrow();
-      expect(userModel.frontend).not.toBeDefined();
+      decisionsCollection.frontend = 'farmers';
+      expect(decisionsCollection.frontend).toEqual('farmers');
+      userModel.frontend = 'farmers';
+      expect(userModel.frontend).toEqual('farmers');
 
       expect(() => decisionsCollection.models.push({frontend: 'farmers'})).toThrow();
       expect(decisionsCollection.length).toEqual(0);

--- a/test/with-resources.jsx
+++ b/test/with-resources.jsx
@@ -587,10 +587,10 @@ describe('withResources', () => {
       // we know these are the empty models from the previous test
       ({decisionsCollection, userModel} = dataChild.props);
 
-      expect(() => decisionsCollection.frontend = 'farmers').toThrow();
-      expect(decisionsCollection.frontend).not.toBeDefined();
-      expect(() => userModel.frontend = 'farmers').toThrow();
-      expect(userModel.frontend).not.toBeDefined();
+      decisionsCollection.frontend = 'farmers';
+      expect(decisionsCollection.frontend).toEqual('farmers');
+      userModel.frontend = 'farmers';
+      expect(userModel.frontend).toEqual('farmers');
 
       expect(() => decisionsCollection.models.push({frontend: 'farmers'})).toThrow();
       expect(decisionsCollection.length).toEqual(0);


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

Now that assignments to frozen objects are erroring instead of failing silently, we don't actually want to prevent instance properties from being set on models/collections, because that prevents some internal actions from taking place, like setting `this._events`. While these aren't used, now that they don't silently fail, they will unnecessarily impede app development, so it's better to just only freeze the data-carrying objects—`attributes` and `models`.

