### PR TITLE
unignore index.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,5 @@
 **/tmp/**
 
 node_modules
-*.js
 !lib/*.js
 !test/*.js

--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+export {Collection, Model} from 'schmackbone';
+export {default as prefetch} from './lib/prefetch.js';
+export {default as request} from './lib/request.js';
+export {default as ModelCache} from './lib/model-cache.js';
+export {hasErrored, hasLoaded, isLoading, isPending} from './lib/utils.js';
+export {ModelMap, ResourceKeys, ResourcesConfig} from './lib/config.js';
+export {useResources, withResources} from './lib/resourcerer.js';
+export {
+  findDataCarrier,
+  findDataChild,
+  getRenderedResourceComponents,
+  waitsFor
+} from './test/test-utils.js';


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

`*.js` was gitignored previously for built files that were placed top-level. This ignored the new modular `index.js`. We no longer have built files top-level, so we can remove that and reintroduce `index.js` to git.
