### PR TITLE
seed empty model with any attributes or models

### DIFF
--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -119,7 +119,7 @@ export const withResources = (getResources) =>
           ...resources.filter(withoutPrefetch).reduce((models, [name, config]) => ({
             ...models,
             [getResourcePropertyName(name, config.modelKey)]: getModelFromCache(config) ||
-              getEmptyModel(config.modelKey)
+              getEmptyModel(config)
           }), {}),
           ...initialLoadingStates,
           /**
@@ -159,7 +159,7 @@ export const withResources = (getResources) =>
             ...pendingResources.reduce((memo, [name, config]) => Object.assign(memo, {
               // if pending resource cache key doesn't change, don't reset it to empty
               [getResourcePropertyName(name, config.modelKey)]: getModelFromCache(config) ||
-                getEmptyModel(config.modelKey)
+                getEmptyModel(config)
             }), {}),
             ...buildResourcesLoadingState(pendingResources, this.props, LoadingStates.PENDING),
             // but resourcesToUpdate should get set to loading. if in the cache, they'll get reset
@@ -655,13 +655,21 @@ function getResourcePropertyName(baseName, modelKey) {
  * without needing to be defensive. This method freezes an empty instance of
  * the model associated with the modelKey and returns it.
  *
- * @param {string} modelKey - resource type key
+ * We seed the empty model with any attributes or models it intends on having
+ * just in case this is a model given an `options.fetch` of `false`, in which
+ * case we expect that the model should not have a loading state and should
+ * appear as expected immediately.
+ *
+ * @param {string} config - resource config object
  * @return {Model|Collection} empty model or collection instance with frozen
  *   atributes or models, respectively
  */
-function getEmptyModel(modelKey) {
+function getEmptyModel({modelKey, attributes, models, options}) {
   var Model_ = typeof ModelMap[modelKey] === 'function' ? ModelMap[modelKey] : Model,
-      emptyInstance = new Model_();
+      emptyInstance = new Model_(
+        Model_.prototype instanceof Collection ? models : attributes,
+        options
+      );
 
   // flag to differentiate between other model instances that happen to be empty
   emptyInstance.isEmptyModel = true;
@@ -921,7 +929,7 @@ function modelAggregator(resources) {
     ...models,
     ...resources.reduce((memo, [name, config]) => Object.assign(memo, {
       [getResourcePropertyName(name, config.modelKey)]: getModelFromCache(config) ||
-        getEmptyModel(config.modelKey)
+        getEmptyModel(config)
     }), {})
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/use-resources.jsx
+++ b/test/use-resources.jsx
@@ -33,7 +33,7 @@ const getResources = (props) => ({
     ...(props.includeDeleted ? {data: {include_deleted: true}} : {}),
     measure
   },
-  [ResourceKeys.NOTES]: {noncritical: true, dependsOn: ['noah']},
+  [ResourceKeys.NOTES]: {attributes: {pretend: true}, noncritical: true, dependsOn: ['noah']},
   [ResourceKeys.USER]: {
     attributes: {id: props.withId ? props.userId : null},
     data: {
@@ -598,6 +598,7 @@ describe('useResources', () => {
 
       // however, this is a pending resource, so it should not be in the cache
       expect(dataChild.props.notesModel.isEmptyModel).toBe(true);
+      expect(dataChild.props.notesModel.get('pretend')).toBe(true);
       expect(dataChild.props.notesModel instanceof NotesModel).toBe(true);
 
       unmountAndClearModelCache();

--- a/test/with-resources.jsx
+++ b/test/with-resources.jsx
@@ -42,7 +42,7 @@ const jasmineNode = document.createElement('div');
     measure,
     status: props.status
   },
-  [ResourceKeys.NOTES]: {noncritical: true, dependsOn: ['noah']},
+  [ResourceKeys.NOTES]: {attributes: {pretend: true}, noncritical: true, dependsOn: ['noah']},
   [ResourceKeys.USER]: {
     attributes: {id: props.withId ? props.userId : null},
     data: {
@@ -559,6 +559,7 @@ describe('withResources', () => {
 
       // however, this is a pending resource, so it should not be in the cache
       expect(dataChild.props.notesModel.isEmptyModel).toBe(true);
+      expect(dataChild.props.notesModel.get('pretend')).toBe(true);
       expect(dataChild.props.notesModel instanceof NotesModel).toBe(true);
 
       unmountAndClearModelCache();


### PR DESCRIPTION
## Description of Proposed Changes:  
  -  Empty models are now seeded with any `attributes`, `models`, or `options` passed in the executor function
  - Allows any resources with `fetch: false` to be initialized to the correct state even if it will be replaced when the Promise immediately resolves
