### PR TITLE
Render optimizations

### DIFF
--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -149,30 +149,37 @@ export const withResources = (getResources) =>
         var nextResources = this._generateResources(),
             pendingResources = nextResources.filter(not(hasAllDependencies.bind(null, this.props)))
                 .filter(([, config]) => hasAllDependencies(prevProps, [, config])),
-            resourcesToUpdate = this._getResourcesToUpdate(nextResources, prevProps);
+            resourcesToUpdate = this._getResourcesToUpdate(nextResources, prevProps),
+            nextLoadingStates = {
+              ...buildResourcesLoadingState(pendingResources, this.props, LoadingStates.PENDING),
+              // but resourcesToUpdate should get set to LOADING (or LOADED if in the cache)
+              ...buildResourcesLoadingState(resourcesToUpdate.filter(withoutPrefetch), this.props)
+            },
+
+            // separate out those resources to update into those that are already cached and those
+            // that need to be fetched. the former will get the models updated immediately
+            [loadedResources, resourcesToFetch] = partitionResources(
+              resourcesToUpdate,
+              nextLoadingStates
+            );
 
         // first set our updated resources' loading states to LOADING. also, any
         // resources that have lost their dependencies should go back to a pending state
-        // and their models reverted to the empty models
+        // and their models reverted to the empty models. new resources that have already
+        // been loaded should be set to LOADED with their cached models set as state immediately
         if (pendingResources.length || resourcesToUpdate.length) {
           this.setState({
-            ...pendingResources.reduce((memo, [name, config]) => Object.assign(memo, {
-              // if pending resource cache key doesn't change, don't reset it to empty
-              [getResourcePropertyName(name, config.modelKey)]: getModelFromCache(config) ||
-                getEmptyModel(config)
-            }), {}),
-            ...buildResourcesLoadingState(pendingResources, this.props, LoadingStates.PENDING),
-            // but resourcesToUpdate should get set to loading. if in the cache, they'll get reset
-            // to loaded in the resolved fetch's success handler
-            ...buildResourcesLoadingState(
-              resourcesToUpdate.filter(withoutPrefetch),
-              this.props,
-              LoadingStates.LOADING
-            )
+            ...pendingResources.concat(loadedResources).reduce((memo, [name, config]) =>
+              Object.assign(memo, {
+                // if pending resource cache key doesn't change, don't reset it to empty
+                [getResourcePropertyName(name, config.modelKey)]: getModelFromCache(config) ||
+                  getEmptyModel(config)
+              }), {}),
+            ...nextLoadingStates
           });
         }
 
-        resourcesToUpdate.forEach(([name, config]) => {
+        resourcesToFetch.forEach(([name, config]) => {
           var previousConfig = findConfig([name, config], getResources, prevProps),
               previousCacheKey = this._findCurrentCacheKey([name, config], prevProps);
 
@@ -188,8 +195,8 @@ export const withResources = (getResources) =>
           }
         });
 
-        if (resourcesToUpdate.length) {
-          this._fetchResources(resourcesToUpdate);
+        if (resourcesToFetch.length) {
+          this._fetchResources(resourcesToFetch);
         }
 
         if ((this.props.refetches || []).length) {
@@ -394,6 +401,9 @@ export const useResources = (getResources, props) => {
 
       forceUpdate = useForceUpdate(),
       getPrevCacheKey = (rsrc) => findCacheKey(rsrc, getResources, prevPropsRef.current),
+      // note that this only tells when cache keys have changed. if a resource has already been
+      // cached, this will still return its resource when the component mounts. that's why we
+      // partition these out later into loaded and not loaded resources
       getResourcesToUpdate = (rsrcs) => rsrcs.filter(hasAllDependencies.bind(null, props))
           .filter(not(shouldBypassFetch.bind(null, props)))
           .filter(([name, config]) => {
@@ -403,14 +413,17 @@ export const useResources = (getResources, props) => {
               !hasAllDependencies(prevPropsRef.current, [, config]) || config.refetch);
           });
 
-  if (resources.some(([name]) => name === 'integrations')) {
-    console.log(loadingStates, resources);
-  }
-
-  // fetch things
-  // ideally we would re-run this if any of the cache keys have changed, but
-  // right now useEffect can't be run in a dynamic loop--it must be top-level.
-  // so we must manually compare prevProps
+  /**
+   * Fetch things.
+   * Ideally we would re-run this if any of the cache keys have changed, but
+   * right now useEffect can't be run in a dynamic loop--it must be top-level.
+   * So we must manually compare prevProps.
+   *
+   * Note also that every time we set a state, whether it be loading states or models, we are
+   * setting a new object as that state and we will re-render. That means that if a model is cached
+   * or its loading states haven't changed we should _not_ just go ahead and call fetchResources,
+   * because that will re-render our components an additional two times.
+   */
   useEffect(() => {
     var pendingResources = resources.filter(not(hasAllDependencies.bind(null, props)))
             .filter(([, config]) =>
@@ -418,39 +431,33 @@ export const useResources = (getResources, props) => {
         resourcesToUpdate = getResourcesToUpdate(resources),
         nextLoadingStates = {
           ...buildResourcesLoadingState(pendingResources, props, LoadingStates.PENDING),
-          // but resourcesToUpdate should get set to LOADING. if in the cache, they'll get reset
-          // to loaded in the resolved fetch's success handler. this is necessary due to a subtle
-          // bug: without this last argument, anything already cached would go into a LOADED state
-          // while their corresponding model would be the empty model. they must be kept in sync.
-          ...buildResourcesLoadingState(
-            resourcesToUpdate.filter(withoutPrefetch),
-            props,
-            LoadingStates.LOADING
-          )
+          // but resourcesToUpdate should get set to LOADING (or LOADED if in the cache)
+          ...buildResourcesLoadingState(resourcesToUpdate.filter(withoutPrefetch), props)
         },
-        // if this gets re-run because a parent component re-renders before a resource returns,
-        // resourcesToUpdate would still be populated. but we don't actually want to cause re-
-        // renders if loading states haven't changed
-        haveLoadingStatesChanged = Object.keys(nextLoadingStates).length &&
-          Object.keys(nextLoadingStates)
-              .some((key) => nextLoadingStates[key] !== loadingStates[key]);
 
-    console.log(loadingStates, nextLoadingStates);
+        // separate out those resources to update into those that are already cached and those
+        // that need to be fetched. the former will get the models updated immediately
+        [loadedResources, resourcesToFetch] = partitionResources(
+          resourcesToUpdate,
+          nextLoadingStates
+        );
 
-    // first set our updated resources' loading states to LOADING. also, any
+    // first set our updated resources' loading states to LOADING. but don't set if we're already
+    // in a loading state for that resource, because that's a pointless extra render. also, any
     // resources that have lost their dependencies should go back to a pending state
-    if (haveLoadingStatesChanged) {
+    if (Object.keys(nextLoadingStates).some((ky) => nextLoadingStates[ky] !== loadingStates[ky])) {
       loaderDispatch({type: LoadingStates.LOADING, payload: nextLoadingStates});
     }
 
-    // need to remove our model state here because it won't happen after a request like the others,
-    // since no request is being made for pending resources. note that this will stay as the
-    // requested model if the dependent prop does not affect the cache key
-    if (pendingResources.length) {
-      setModels(modelAggregator(pendingResources));
+    // pending resources: need to remove our model state here because it won't happen after a
+    // request like the others, since no request is being made for pending resources. note that
+    // this will stay as the requested model if the dependent prop does not affect the cache key.
+    // loaded resources: we also don't fetch these, so we need to set our models immediately
+    if (pendingResources.concat(loadedResources).length) {
+      setModels(modelAggregator(pendingResources.concat(loadedResources)));
     }
 
-    if (resourcesToUpdate.length) {
+    if (resourcesToFetch.length) {
       if (prevPropsRef.current) {
         resourcesToUpdate.forEach(([name, config]) => {
           var prevConfig = findConfig([name, config], getResources, prevPropsRef.current),
@@ -779,7 +786,7 @@ function findCacheKey(resource, getResources, props) {
 function buildResourcesLoadingState(resources, props, defaultState=LoadingStates.LOADED) {
   return resources.reduce((state, [name, config]) => Object.assign(state, {
     [getResourceState(name)]:
-      shouldBypassFetch(props, [name, config]) || getModelFromCache(config) ?
+      !config.refetch && (shouldBypassFetch(props, [name, config]) || getModelFromCache(config)) ?
         defaultState :
         (!hasAllDependencies(props, [, config]) ? LoadingStates.PENDING : LoadingStates.LOADING)
   }), {});
@@ -930,20 +937,42 @@ function getCriticalLoadingStates(loadingStates, resources) {
 /**
  * Helper method whose return function aggregates all models to be set as model
  * state in the useResources hook. Pulls model from the cache or assigns the
- * empty model if one does not exist.
+ * empty model if one does not exist. If no models have actually changed from
+ * current state, we don't set a new object as state to avoid rerendering.
  *
  * @param {array[]} resources - list of resource config entries
  * @return {function} function that can be passed to a state-setting function
  *   that returns models keyed by name
  */
 function modelAggregator(resources) {
-  return (models={}) => ({
-    ...models,
-    ...resources.reduce((memo, [name, config]) => Object.assign(memo, {
-      [getResourcePropertyName(name, config.modelKey)]: getModelFromCache(config) ||
-        getEmptyModel(config)
-    }), {})
-  });
+  var newModels = resources.reduce((memo, [name, config]) => Object.assign(memo, {
+    [getResourcePropertyName(name, config.modelKey)]: getModelFromCache(config) ||
+      getEmptyModel(config)
+  }), {});
+
+  return (models={}) => Object.keys(newModels).filter(
+    // this comparison is so that if no models have changed, we don't change state and rerender.
+    // this is only important when a model is cached when a component mounts, because it will still
+    // be included in resourcesToUpdate even though its model will be seeded in state already
+    (key) => models[key] !== newModels[key]
+  ).length ? {...models, ...newModels} : models;
+}
+
+/**
+ * Separates out resources between those that are loading and those that have loaded. The latter
+ * won't need to get passed to fetchResources, but the former will.
+ *
+ * @param {array[]} resourcesToUpdate - resource configs to partition
+ * @param {object} loadingStates - contains upcoming loading states for each resource
+ * @return {[array[], array[]]} partitioned tuple of resources that have been loaded and resources
+ *   that should be passed to fetchResources
+ */
+function partitionResources(resourcesToUpdate, loadingStates) {
+  return resourcesToUpdate.reduce((memo, [name, config]) =>
+    config.refetch || !hasLoaded(loadingStates[getResourceState(name)]) ?
+      [memo[0], memo[1].concat([[name, config]])] :
+      [memo[0].concat([[name, config]]), memo[1]],
+  [[], []]);
 }
 
 /**

--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -403,6 +403,10 @@ export const useResources = (getResources, props) => {
               !hasAllDependencies(prevPropsRef.current, [, config]) || config.refetch);
           });
 
+  if (resources.some(([name]) => name === 'integrations')) {
+    console.log(loadingStates, resources);
+  }
+
   // fetch things
   // ideally we would re-run this if any of the cache keys have changed, but
   // right now useEffect can't be run in a dynamic loop--it must be top-level.
@@ -423,11 +427,19 @@ export const useResources = (getResources, props) => {
             props,
             LoadingStates.LOADING
           )
-        };
+        },
+        // if this gets re-run because a parent component re-renders before a resource returns,
+        // resourcesToUpdate would still be populated. but we don't actually want to cause re-
+        // renders if loading states haven't changed
+        haveLoadingStatesChanged = Object.keys(nextLoadingStates).length &&
+          Object.keys(nextLoadingStates)
+              .some((key) => nextLoadingStates[key] !== loadingStates[key]);
+
+    console.log(loadingStates, nextLoadingStates);
 
     // first set our updated resources' loading states to LOADING. also, any
     // resources that have lost their dependencies should go back to a pending state
-    if (Object.keys(nextLoadingStates).length) {
+    if (haveLoadingStatesChanged) {
       loaderDispatch({type: LoadingStates.LOADING, payload: nextLoadingStates});
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/use-resources.jsx
+++ b/test/use-resources.jsx
@@ -1189,32 +1189,22 @@ describe('useResources', () => {
     expect(requestSpy.calls.count()).toEqual(4);
   });
 
-  it('still puts cached resource into a loading state before re-fetching, to keep in sync ' +
-      'with model', async(done) => {
-    var zorahModel = new UserModel(),
-        ok;
+  it('cached resources are initialized into a loaded state and not re-fetched', async(done) => {
+    var zorahModel = new UserModel();
 
     ModelCache.put('userfraudLevel=high_userId=zorah', zorahModel);
     dataChild = findDataChild(renderUseResources());
 
     await waitsFor(() => dataChild.props.hasLoaded);
+    expect(requestSpy.calls.count()).toEqual(3);
 
-    // just leave it hanging for a bit so that we can actually make our loading state assertion
-    requestSpy.and.callFake(() => new Promise((res) => {
-      var interval = window.setInterval(() => {
-        if (ok) {
-          window.clearInterval(interval);
-          res([zorahModel]);
-        }
-      }, 100);
-    }));
     dataChild = findDataChild(renderUseResources({userId: 'zorah'}));
 
-    await waitsFor(() => dataChild.props.userLoadingState === LoadingStates.LOADING);
-    expect(dataChild.props.hasLoaded).toBe(false);
-    ok = true;
+    // just wait a small amount to make sure things don't change
+    await new Promise((res) => window.setTimeout(res, 0));
 
-    await waitsFor(() => dataChild.props.hasLoaded);
+    expect(dataChild.props.userId).toEqual('zorah');
+    expect(requestSpy.calls.count()).toEqual(3);
     expect(dataChild.props.userLoadingState).toEqual(LoadingStates.LOADED);
     expect(dataChild.props.hasLoaded).toBe(true);
 

--- a/test/with-resources.jsx
+++ b/test/with-resources.jsx
@@ -1315,32 +1315,22 @@ describe('withResources', () => {
     expect(requestSpy.calls.count()).toEqual(4);
   });
 
-  it('still puts cached resource into a loading state before re-fetching, to keep in sync ' +
-      'with model', async(done) => {
-    var zorahModel = new UserModel(),
-        ok;
+  it('cached resources are initialized into a loaded state and not re-fetched', async(done) => {
+    var zorahModel = new UserModel();
 
     ModelCache.put('userfraudLevel=high_userId=zorah', zorahModel);
     dataChild = findDataChild(renderWithResources());
 
     await waitsFor(() => dataChild.props.hasLoaded);
+    expect(requestSpy.calls.count()).toEqual(3);
 
-    // just leave it hanging for a bit so that we can actually make our loading state assertion
-    requestSpy.and.callFake(() => new Promise((res) => {
-      var interval = window.setInterval(() => {
-        if (ok) {
-          window.clearInterval(interval);
-          res([zorahModel]);
-        }
-      }, 100);
-    }));
     dataChild = findDataChild(renderWithResources({userId: 'zorah'}));
 
-    await waitsFor(() => dataChild.props.userLoadingState === LoadingStates.LOADING);
-    expect(dataChild.props.hasLoaded).toBe(false);
-    ok = true;
+    // just wait a small amount to make sure things don't change
+    await new Promise((res) => window.setTimeout(res, 0));
 
-    await waitsFor(() => dataChild.props.hasLoaded);
+    expect(dataChild.props.userId).toEqual('zorah');
+    expect(requestSpy.calls.count()).toEqual(3);
     expect(dataChild.props.userLoadingState).toEqual(LoadingStates.LOADED);
     expect(dataChild.props.hasLoaded).toBe(true);
 


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

Fixes a couple of issues related to superfluous rendering:
* useResources was initially double-rendering because of the loading state getting set in the useEffect
* resources that have already been cached were being set briefly to a loading state and then going through fetchResources' resolve handler to get their models set as state, causing an extra render with the `loading` state and the model state being separate. now the loading state gets set to `loaded` and the model is set in the same batch.

## Description of Proposed Changes:  
  -  further splits out resourcesToUpdate into those that need to be fetched and those that have already loaded
  -  bails out of a model state update if the model has not actually changed
  -  bails out of a loading state update in the hook if the loading states haven't actually changed

