### PR TITLE
dont use prefetch in model aggregator

### DIFF
--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -169,12 +169,12 @@ export const withResources = (getResources) =>
         // been loaded should be set to LOADED with their cached models set as state immediately
         if (pendingResources.length || resourcesToUpdate.length) {
           this.setState({
-            ...pendingResources.concat(loadedResources).reduce((memo, [name, config]) =>
-              Object.assign(memo, {
-                // if pending resource cache key doesn't change, don't reset it to empty
-                [getResourcePropertyName(name, config.modelKey)]: getModelFromCache(config) ||
-                  getEmptyModel(config)
-              }), {}),
+            ...pendingResources.concat(loadedResources).filter(withoutPrefetch)
+                .reduce((memo, [name, config]) => Object.assign(memo, {
+                  // if pending resource cache key doesn't change, don't reset it to empty
+                  [getResourcePropertyName(name, config.modelKey)]: getModelFromCache(config) ||
+                    getEmptyModel(config)
+                }), {}),
             ...nextLoadingStates
           });
         }
@@ -454,10 +454,15 @@ export const useResources = (getResources, props) => {
     // this will stay as the requested model if the dependent prop does not affect the cache key.
     // loaded resources: we also don't fetch these, so we need to set our models immediately
     if (pendingResources.concat(loadedResources).length) {
-      setModels(modelAggregator(pendingResources.concat(loadedResources)));
+      setModels(modelAggregator(pendingResources.concat(loadedResources).filter(withoutPrefetch)));
     }
 
-    if (resourcesToFetch.length) {
+    // NOTE: changing this to resourcesToFetch causes some inexplicable bugs around cached resources
+    // and a UI that wouldn't update. so this is kept as resourcesToUpdate and fetchResources is
+    // given resourcesToFetch. Because we are still only fetching resourcesToFetch and because any
+    // loaded resources will have already had their models set above, and any loaded prefetched
+    // models do not have loading or model states, this should have no practical effect
+    if (resourcesToUpdate.length) {
       if (prevPropsRef.current) {
         resourcesToUpdate.forEach(([name, config]) => {
           var prevConfig = findConfig([name, config], getResources, prevPropsRef.current),
@@ -476,7 +481,7 @@ export const useResources = (getResources, props) => {
         });
       }
 
-      fetchResources(resourcesToUpdate, props, {
+      fetchResources(resourcesToFetch, props, {
         component: componentRef.current,
         isCurrentResource: ([name, config], cacheKey) => isMountedRef.current && !config.prefetch &&
           cacheKey === findCacheKey([name, config], getResources, currentPropsRef.current),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [
@@ -47,7 +47,7 @@
     "schmackbone": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0"
   }
 }


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
A regression where prefetched models were being applied to cached resources

## Description of Proposed Changes:  
  -  `modelAggregator` should only ever get non-prefetched resources`
 
