### PR TITLE
is or will be loading only for resources to fetch

### DIFF
--- a/ADVANCED_TOPICS.md
+++ b/ADVANCED_TOPICS.md
@@ -212,7 +212,7 @@ export default function UserTodos(props) {
 }
 ```
 
-## isOrWillBeLoading
+## isOrWillBeLoading (`useResources` only)
 
 Taking the previous example of [Loading Overlays](#loading-overlays) just a bit further, what if the todosCollection was 5000 entries long? Okay, you'd probably paginate. But that's not the point! Let's say it's an `<ExpensiveComponent />`, and as it is now, when we change loading states, the parent `MyComponent` would render `<ExpensiveComponent />` on every change, which will kill your UX. So let's wrap it in a `React.memo`!
 

--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -294,18 +294,6 @@ export const withResources = (getResources) =>
         }
       }
 
-      // NOTE: this must be bound here to keep React.memo working when shallow-comparing props
-      _isOrWillBeLoading = () => {
-        var resources = this._generateResources().filter(withoutPrefetch),
-            loadingStates = getCriticalLoadingStates(this.state, resources);
-
-        return !hasLoaded(loadingStates) ||
-          !!this._getResourcesToUpdate(
-            resources.filter(withoutNoncritical).filter(withoutPrefetch),
-            this.prevPropsRef.current
-          ).length;
-      }
-
       _onModelEvent() {
         this.forceUpdate();
       }
@@ -373,7 +361,6 @@ export const withResources = (getResources) =>
               isLoading={isLoading(loadingStates)}
 
               // helpers
-              isOrWillBeLoading={this._isOrWillBeLoading}
               refetch={this._refetch}
             />
           </ErrorBoundary>
@@ -611,8 +598,18 @@ export const useResources = (getResources, props) => {
     ..._resourceState,
 
     // helpers
-    isOrWillBeLoading: () => !hasLoaded(criticalLoadingStates) ||
-      !!getResourcesToUpdate(resources.filter(withoutNoncritical).filter(withoutPrefetch)).length,
+    isOrWillBeLoading: () => {
+      var resourcesToUpdate = getResourcesToUpdate(
+        resources.filter(withoutNoncritical).filter(withoutPrefetch)
+      );
+
+      // here we only look at resources to fetch, not loaded ones
+      return !hasLoaded(criticalLoadingStates) || !!partitionResources(
+        resourcesToUpdate,
+        // 'next' loading states
+        buildResourcesLoadingState(resourcesToUpdate, props)
+      )[1].length;
+    },
     refetch: (fn) => {
       var refetches = fn(ResourceKeys);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/with-resources.jsx
+++ b/test/with-resources.jsx
@@ -1352,26 +1352,6 @@ describe('withResources', () => {
 
     await waitsFor(() => dataChild.props.hasLoaded);
   });
-
-  it('isOrWillBeLoading is true for two cycles that props change and loading starts', async() => {
-    dataChild = findDataChild(renderWithResources());
-
-    expect(dataChild.props.isOrWillBeLoading()).toBe(true);
-    await waitsFor(() => dataChild.props.hasLoaded);
-    expect(dataChild.props.isOrWillBeLoading()).toBe(false);
-
-    dataChild.props.setResourceState({userId: 'alex'});
-    // in contrast to useResources, cDU gets executed in the same stack and
-    // so we can't assert that for a frame the following two lines are true,
-    // even though they indeed are. render gets called twice before we yield
-    // back to the test script.
-    // expect(dataChild.props.hasLoaded).toBe(true);
-    // expect(dataChild.props.isLoading).toBe(false);
-    expect(dataChild.props.isOrWillBeLoading()).toBe(true);
-
-    await waitsFor(() => dataChild.props.hasLoaded);
-    expect(dataChild.props.isOrWillBeLoading()).toBe(false);
-  });
 });
 /* eslint-enable max-nested-callbacks */
 


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
An issue where after v0.11.3 `isOrWillBeLoading` was not rendering a final (third) time when there were no resources to update if the resource had already been cached.

## Description of Proposed Changes:  
  -  Look for `resourcesToFetch` instead of all resourcesToUpdate when determining if we will be loading
  
