### PR TITLE
silent clear call when request errors

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -254,7 +254,8 @@ export default class Model {
         })
         .catch((response) => {
           if (!options.wait) {
-            this.clear().set(previousAttributes, options);
+            // keep the clear silent so that we only render when we reset attributes
+            this.clear({silent: true}).set(previousAttributes, options);
           } else {
             this.attributes = previousAttributes;
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.0-alpha-2",
+  "version": "1.0.0-alpha-3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.0-alpha-2",
+  "version": "1.0.0-alpha-3",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
- Save errors would render twice—once upon clearing the model and then once upon setting previous attributes. We should only be rendering on the latter.
