### PR TITLE
do not export removed testing utils

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,9 +12,3 @@ export {
 } from './lib/utils.js';
 export {ModelMap, ResourceKeys, ResourcesConfig} from './lib/config.js';
 export {useResources, withResources} from './lib/resourcerer.js';
-export {
-  findDataCarrier,
-  findDataChild,
-  getRenderedResourceComponents,
-  waitsFor
-} from './test/test-utils.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "1.0.0-beta-1",
+  "version": "1.0.0-beta-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "1.0.0-beta-1",
+      "version": "1.0.0-beta-2",
       "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.0-beta-1",
+  "version": "1.0.0-beta-2",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

Bug in the first beta release where removed test utils were still exported.
