### PR TITLE
use correct prefetch `getResources` parameter ordering

### DIFF
--- a/lib/prefetch.js
+++ b/lib/prefetch.js
@@ -13,14 +13,14 @@ const PREFETCH_TIMEOUT = 50;
  *
  * @param {function} getResources - function that takes props as an argument
  *   and should return a map of resources. Identical to those used in
- *   `withResources` HOC
+ *   `useResources`/`withResources`
  * @param {object} expectedProps - props in the form expected when the resource
  *   would be needed
  * @return {function} callback to be invoked onMouseEnter of appropriate DOM el
  */
 export default (getResources, expectedProps={}) => {
   var fetched,
-      resources = Object.entries(getResources(expectedProps, ResourceKeys) || {});
+      resources = Object.entries(getResources(ResourceKeys, expectedProps) || {});
 
   return (evt) => {
     var {target} = evt,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "1.0.0-beta-2",
+  "version": "1.0.0-beta-3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "1.0.0-beta-2",
+      "version": "1.0.0-beta-3",
       "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.0-beta-2",
+  "version": "1.0.0-beta-3",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/prefetch.test.js
+++ b/test/prefetch.test.js
@@ -6,7 +6,7 @@ import prefetch from '../lib/prefetch';
 import ReactDOM from 'react-dom';
 
 const renderNode = document.createElement('div');
-const getResources = (props, {DECISIONS, USER}) => ({
+const getResources = ({DECISIONS, USER}, props) => ({
   [USER]: {
     data: {home: props.home, source: props.source},
     options: {userId: props.userId}


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
The `prefetch` module did not get its `getResources` parameter ordering updated, so the `ResourceKeys` and `expectedProps` are inverted. This fixes that.


## Description of Proposed Changes:  
  -  swaps the ordering of the executor function parameters in the prefetch module

