### PR TITLE
Rename params

### DIFF
--- a/docs/advanced_topics.md
+++ b/docs/advanced_topics.md
@@ -120,12 +120,6 @@ UnfetchedResources.add(ResourceKeys.ACCOUNT_CONFIG);
 
 // account_model.js
 export default class AccountModel extends Model {
-  constructor(attrs, options) {
-    super();
-    
-    this.accountId = options.accountId;
-  }
-  
   url() {
     return `/accounts/${this.accountId}`;
   }

--- a/docs/advanced_topics.md
+++ b/docs/advanced_topics.md
@@ -69,7 +69,7 @@ Another way to effectively have a dependent resource is to use a conditional in 
 ```js
 const getResources = (ResourceKeys, props) => ({
   [ResourceKeys.TODOS]: {},
-  ...(props.todoId ? {[ResourceKeys.TODO_ITEM]: {attributes: {id: props.todoId}} : {})
+  ...(props.todoId ? {[ResourceKeys.TODO_ITEM]: {data: {id: props.todoId}} : {})
 });
 ```
 
@@ -90,7 +90,7 @@ const getResources = (ResourceKeys, {userId, orderId}) => ({
   ...!userId && orderId ? {
     [ResourceKeys.ORDER]: {
       noncritical: true,
-      attributes: {id: orderId}
+      data: {id: orderId}
     }
   } : {}
 });
@@ -133,7 +133,7 @@ export default class AccountModel extends Model {
   static cacheFields = ['accountId']
   
   static providesModels = (accountModel, ResourceKeys) => [{
-    attributes: accountModel.get('config'),
+    data: accountModel.get('config'),
     modelKey: ResourceKeys.ACCOUNT_CONFIG,
     options: {accountModel}
   }]
@@ -154,7 +154,7 @@ class ChildComponent extends React.Component {
 }
 ```
 
-In general, this should be used in cases where you can ascertain that the parent model has returned before trying to access the child model. However, if by chance it has not, and the child is not found in the cache, `resourcerer` will still not attempt to fetch it, because it is listed within the `UnfetchedResources` set. In that case, the model will get instantiated with no seed attributes and passed as a prop.
+In general, this should be used in cases where you can ascertain that the parent model has returned before trying to access the child model. However, if by chance it has not, and the child is not found in the cache, `resourcerer` will still not attempt to fetch it, because it is listed within the `UnfetchedResources` set. In that case, the model will get instantiated with no seed data and passed as a prop.
 
 Also, note that the `modelKey` property is required here instead of optionally being inferred from the resource config's object property, as is the case in our general `useResources`/`withResources` declarations. This is because here, in contrast, the models are simply placed in the cache and not actually used as props for any component, so they don't need to be named. Accordingly, resource configs are also returned as a list here instead of an object.
 
@@ -167,7 +167,7 @@ export default class AccountModel extends Model {
   static cacheFields: ['accountId']
   
   static providesModels = (accountModel, ResourceKeys) => [{
-    attributes: accountModel.get('config'),
+    data: accountModel.get('config'),
     modelKey: ResourceKeys.ACCOUNT_CONFIG,
     options: {accountModel},
     // if this returns false, account config won't get instantiated and placed in the ModelCache
@@ -267,7 +267,7 @@ import {useResources} from 'resourcerer';
 
 const getResources = ({TODO}, props) => ({
   [TODO]: {
-    attributes: {id: props.id},
+    data: {id: props.id},
     fetch: !!props.id
   }
 });

--- a/docs/collection.md
+++ b/docs/collection.md
@@ -30,7 +30,7 @@ that you might find useful in rendering your data-hydrated components.
 Add this on your Collection definition to tell it how it should sort its models. It can take three forms:
 
 1. A string. In this case, it represents the model property to sort by.
-2. A function with a single argument. In this case, it takes a model's attributes as an argument and returns the value by which it should sort.
+2. A function with a single argument. In this case, it takes a model's data as an argument and returns the value by which it should sort.
 3. A function with two arguments. This is used to sort the collection's models via the native [Array.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) method.  
 
 ### length
@@ -83,7 +83,7 @@ Passing in a `model` option or a `comparator` option to an instance's constructo
 add: Collection (models: (Object|Model)|Array<Object|Model>, options: Object)
 ```
 
-Add a new entry or list of entries into the collection. Each entry can be an object of attributes or a Model instance. Will trigger an update in all subscribed components unless the `trigger: true` option is passed. You can also pass a `parse: true` option to run the model through its [parse](/docs/model.md#parse) method before setting its properties. If an entry already exists on the collection, the new properties will get merged into its existing model.
+Add a new entry or list of entries into the collection. Each entry can be an object of data or a Model instance. Will trigger an update in all subscribed components unless the `trigger: true` option is passed. You can also pass a `parse: true` option to run the model through its [parse](/docs/model.md#parse) method before setting its properties. If an entry already exists on the collection, the new properties will get merged into its existing model.
 
 ### create
 ```js
@@ -116,7 +116,7 @@ Collections index their Model instances by either the Model's [`idAttribute`](/d
 has: boolean (identifier: string|number|Model|object)
 ```
 
-Returns whether or not a model exists in a collection. You can pass the model instance itself, a model's attributes, or a model's id.
+Returns whether or not a model exists in a collection. You can pass the model instance itself, a model's data, or a model's id.
 
 ### modelId
 ```js
@@ -161,14 +161,14 @@ Use this to remove a model or models from the collection, which should not often
 reset: Collection (models: Array<Object|Model>, options: Object)
 ```
 
-Removes all models and their references from a collection and replaces them with the models passed in. Pass in `silent: true` for subscribed components _not_ to get rerendered, and `parse: true` to have data attributes get parsed before being set on their respective models.
+Removes all models and their references from a collection and replaces them with the models passed in. Pass in `silent: true` for subscribed components _not_ to get rerendered, and `parse: true` to have data get parsed before being set on their respective models.
 
 ### set
 ```js
 set: Collection (models: (Object|Model)|Array<Object|Model>, options: Object)
 ```
 
-This is the method that many other write methods (`add`, `remove`, `save`, `reset`, etc) use under the hood, and it should _rarely if ever_ need to be used directly in your application. Sets new attributes as models and merges existing attributes with their models, and sorts as necessary. Pass in `silent: true` for subscribed components _not_ to get rerendered, and `parse: true` to have data attributes get parsed before being set on their respective models.  
+This is the method that many other write methods (`add`, `remove`, `save`, `reset`, etc) use under the hood, and it should _rarely if ever_ need to be used directly in your application. Sets new data as models and merges existing data with their models, and sorts as necessary. Pass in `silent: true` for subscribed components _not_ to get rerendered, and `parse: true` to have data get parsed before being set on their respective models.  
 
 ### sync
 This is just a proxy for the [sync](/lib/sync.js) module. Its behavior shouldn't be overridden, but it may be useful to wrap it for custom behavior, ie:
@@ -187,7 +187,7 @@ Collection.sync = Model.sync = function(model, options) {
 toJSON: Array<Object> ()
 ```
 
-Returns each model's data attributes in a new array.
+Returns each model's data objects in a new array.
 
 ## Utility instance methods
 
@@ -245,4 +245,4 @@ Same signature as Array.prototype.slice across a collection's models.
 where: Array<Model> (attrs: object)
 ```
 
-Returns a list of models matching the attribute values passed in. Like `.filter` but a shorthand that uses matching attribute values instead of a predicate function.
+Returns a list of models matching the data values passed in. Like `.filter` but a shorthand that uses matching data values instead of a predicate function.

--- a/docs/collection.md
+++ b/docs/collection.md
@@ -9,12 +9,8 @@ class MyTodos extends Collection {
 }
 
 class MyTodos extends Collection {
-  constructor(models, options={}) {
-    this.subtype = options.subtype;
-  }
-
-  url() {
-    return `/todos/${this.subtype}`;
+  url({subtype}) {
+    return `/todos/${subtype}`;
   }
 }
 ```
@@ -59,23 +55,24 @@ A boolean or function that accepts a [resource configuration object](https://git
 constructor: void (models: Array<Object|Model>, options: object)
 ```
 
-The Collection's constructor gets passed any initial models, as well as the options from the executor function. Override this to set some instance variables for the collection, which is really useful for url path parameters. Just be sure to pass the arguments to its `.super()` call, as well:
+The Collection's constructor gets passed any initial models, as well as the options from the executor function. Override this to add some custom logic or instance variables for the collection&mdash;just be sure to pass the arguments to its `.super()` call, as well:
 
 ```js
 class MyCollection extends Collection {
   constructor(models, options={}) {
     super(models, options);
     
-    this.category = options.category;
+    // initializing some variable to be used later
+    this.categoriesList = [];
   }
   
-  url() {
-    return `/todos/${this.category}`;
+  url({category}) {
+    return `/todos/${category}`;
   }
 }
 ```
 
-Passing in a `model` option or a `comparator` option to an instance's constructor will override the statically defined properties on its constructor.
+Passing in a `model` option or a `comparator` option to an instance's constructor will override the statically defined properties on its constructor. Other `options` fields (from the executor function) are passed to the `url` as shown in the example above.
 
 
 ### add

--- a/docs/model.md
+++ b/docs/model.md
@@ -53,7 +53,7 @@ Override this to be the property name of the Model's unique identifier if it som
 ### `static` defaults
 `object|function`
 
-An object or function that returns object with attribute keys and their default values. If set, then when the model is instantiated, any missing attributes get set to these values.
+An object or function that returns object with attribute keys and their default values. If set, then when the model is instantiated, any missing data get set to these values.
 
 ### `static` measure
 `boolean|function`
@@ -67,15 +67,15 @@ A boolean or function that accepts a [resource configuration object](https://git
 ### constructor
 
 ```js
-constructor: void (attributes: Object, options: object)
+constructor: void (initialData: Object, options: object)
 ```
 
-The Model's constructor gets passed any initial attributes, as well as the options from the executor function. Override this to set some instance variables for the model, which is really useful for url path parameters. Just be sure to pass the arguments to its `.super()` call, as well:
+The Model's constructor gets passed any initial data, as well as the options from the executor function. Override this to set some instance variables for the model, which is really useful for url path parameters. Just be sure to pass the arguments to its `.super()` call, as well:
 
 ```js
 class MyModel extends Model {
-  constructor(attributes, options={}) {
-    super(attributes, options);
+  constructor(initialData, options={}) {
+    super(initialData, options);
     
     this.category = options.category;
   }
@@ -86,7 +86,7 @@ class MyModel extends Model {
 }
 ```
 
-Note that `this.id` is automatically set to whichever value is passed in at the `idAttribute` key (default: 'id'). Pass the `parse: true` option to have the attributes get run through the Model's `parse` method before getting set.
+Note that `this.id` is automatically set to whichever value is passed in at the `idAttribute` key (default: 'id'). Pass the `parse: true` option to have the data get run through the Model's `parse` method before getting set.
 
 
 ### toJSON
@@ -94,7 +94,7 @@ Note that `this.id` is automatically set to whichever value is passed in at the 
 toJSON: Object ()
 ```
 
-Returns the model's data attributes in a new object.
+Returns the model's data in a new object.
 
 ### get
 ```js
@@ -144,7 +144,7 @@ parse(response) {
 
 ### set
 ```js
-set: Model (attributes: object, options: object)
+set: Model (data: object, options: object)
 ```
 
 This is the main avenue by which a model's properties get values assigned. It's called internally by several public methods, including `save`, `unset`, and `clear`. Pass a `silent: true` option for this not to trigger a re-render for subscribed components.
@@ -161,21 +161,21 @@ Removes the attribute from the model's data. Pass a `silent: true` option for th
 clear: Model (options: object)
 ```
 
-Removes all attributes from the model. Pass a `silent: true` option for this not to trigger a re-render for subscribed components.
+Removes all data from the model. Pass a `silent: true` option for this not to trigger a re-render for subscribed components.
 
 ### pick
 ```js
-pick: object (...attributes: Array<string>)
+pick: object (...data: Array<string>)
 ```
 
-Handy helper method to only return a subset of a model's attributes, as opposed to the whole thing like [`.toJSON()`](#tojson) does.
+Handy helper method to only return a subset of a model's data, as opposed to the whole thing like [`.toJSON()`](#tojson) does.
 
 ### save
 ```js
-save: Promise<[Model, Response]> (attributes: object, options: object)
+save: Promise<[Model, Response]> (data: object, options: object)
 ```
 
-Use this to persist data mutations to the server. If [`.isNew()`](#isnew) is true, the request will be sent as a POST. Otherwise, it will be sent as a PUT with the whole resource, or a PATCH with only `attributes` sent over if the `patch: true` option is passed. When the request returns, the server data is passed through the [`.parse()`](#parse) method before being set on the model. Pass the `wait: true` option to wait to add the data until after the server responds. Subscribed components will update when the new entry is added as well as when the request returns. If the request errors, all changes will be reverted and components updated.
+Use this to persist data mutations to the server. If [`.isNew()`](#isnew) is true, the request will be sent as a POST. Otherwise, it will be sent as a PUT with the whole resource, or a PATCH with only `data` sent over if the `patch: true` option is passed. When the request returns, the server data is passed through the [`.parse()`](#parse) method before being set on the model. Pass the `wait: true` option to wait to add the data until after the server responds. Subscribed components will update when the new entry is added as well as when the request returns. If the request errors, all changes will be reverted and components updated.
 
 ***All .save() calls must have a .catch attached, even if the rejection is swallowed. Omitting one risks an uncaught Promise rejection exception if the request fails.***
 

--- a/docs/model.md
+++ b/docs/model.md
@@ -70,23 +70,23 @@ A boolean or function that accepts a [resource configuration object](https://git
 constructor: void (initialData: Object, options: object)
 ```
 
-The Model's constructor gets passed any initial data, as well as the options from the executor function. Override this to set some instance variables for the model, which is really useful for url path parameters. Just be sure to pass the arguments to its `.super()` call, as well:
+The Model's constructor gets passed any initial data, as well as the options from the executor function. Override this to add some custom logic or instance variables for the model&mdash;just be sure to pass the arguments to its `.super()` call, as well:
 
 ```js
 class MyModel extends Model {
   constructor(initialData, options={}) {
     super(initialData, options);
     
-    this.category = options.category;
+    // custom logic
   }
   
-  url() {
-    return `/todos/${this.category}/${this.id}`;
+  url({category}) {
+    return `/todos/${category}/${this.id}`;
   }
 }
 ```
 
-Note that `this.id` is automatically set to whichever value is passed in at the `idAttribute` key (default: 'id'). Pass the `parse: true` option to have the data get run through the Model's `parse` method before getting set.
+Note that `this.id` is automatically set to whichever value is passed in at the `idAttribute` key (default: 'id'). Pass the `parse: true` option to have the data get run through the Model's `parse` method before getting set. Other `options` fields (from the executor function) are passed to the `url` as shown in the example above.
 
 
 ### toJSON

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -22,16 +22,23 @@ export default class Collection {
    *   through the parse method and {silent: true} to not trigger any updates. in the default
    *   constructor, use:
    *
-   *   * model {Model} - dynamically overrides the static model property for the type of Model that
+   *   * Model {Model} - dynamically overrides the static model property for the type of Model that
    *     this collection's models should be instances of
    *   * comparator {function|string} - dynamically overrides the static comparator property used to
    *     sort the collection
    */
   constructor(models, options={}) {
+    const RESERVED_OPTION_KEYS = ['Model', 'comparator', 'silent', 'parse'];
+
     this.Model = options.Model || this.constructor.Model;
     this.comparator = options.comparator || this.constructor.comparator;
 
     this._reset();
+
+    this.urlOptions = Object.keys(options).reduce((memo, key) => Object.assign(
+      memo,
+      !RESERVED_OPTION_KEYS.includes(key) ? {[key]: options[key]} : {}
+    ), {});
 
     if (models) {
       // silent for completeness, i guess. but a nothing triggered here because it's impossible for

--- a/lib/config.js
+++ b/lib/config.js
@@ -106,12 +106,12 @@ export const ResourcesConfig = {
    * but that won't handle complex values (arrays and objects). To add support for that, override
    * this method with any logic or stringify library you want.
    *
-   * @param {object} data - request data
+   * @param {object} params - request params
    * @param {object} options - request options map
    * @return {string} URL query parameter string
    */
-  stringify(data, options) {
-    return new URLSearchParams(data).toString();
+  stringify(params, options) {
+    return new URLSearchParams(params).toString();
   },
 
   /** {function}: Hook to send resource request times to a tracking service. */

--- a/lib/model.js
+++ b/lib/model.js
@@ -19,12 +19,15 @@ export default class Model {
   /**
    * @param {object} attributes - initial server data representation to be kept on the model
    * @param {object} options - generic map. in the default constructor, use:
+   *     url() method
    *   * parse {boolean} - if true, runs the initial attributes through the parse function beefore
    *     setting on the model
    *   * collection {Collection} - links this model to a collection, if applicable
    *   * ...any other options that .set() takes
    */
   constructor(attributes={}, options={}) {
+    const RESERVED_OPTION_KEYS = ['parse', 'collection', 'silent', 'unset'];
+
     this.cid = uniqueId('c');
     this.attributes = {};
 
@@ -35,6 +38,11 @@ export default class Model {
     if (options.parse) {
       attributes = this.parse(attributes, options) || {};
     }
+
+    this.urlOptions = Object.keys(options).reduce((memo, key) => Object.assign(
+      memo,
+      !RESERVED_OPTION_KEYS.includes(key) ? {[key]: options[key]} : {}
+    ), {});
 
     this.set({...result(this.constructor, 'defaults'), ...attributes}, options);
   }
@@ -314,8 +322,9 @@ export default class Model {
    *
    * @return {string} the url endpoint to request for this particular model instance
    */
-  url() {
-    var base = result(this, 'urlRoot') || result(this.collection, 'url') || urlError();
+  url(options=this.urlOptions) {
+    var base = result(this, 'urlRoot', options) || result(this.collection, 'url', options) ||
+      urlError();
 
     if (this.isNew()) {
       return base;

--- a/lib/request.js
+++ b/lib/request.js
@@ -53,6 +53,7 @@ export default (key, Model, options={}) => {
   options = {
     data: Model && Model.prototype instanceof Collection ? [] : {},
     params: {},
+    options: {},
     fetch: true,
     forceFetch: false,
     method: 'GET',
@@ -62,7 +63,7 @@ export default (key, Model, options={}) => {
   if (!loadingCache[key]) {
     _promise = new Promise((resolve, reject) => {
       if (!model || options.forceFetch) {
-        model = model || new Model(options.data, options.options || {});
+        model = model || new Model(options.data, options.options);
 
         if (options.fetch) {
           addToLoadingCache = true;

--- a/lib/request.js
+++ b/lib/request.js
@@ -35,12 +35,11 @@ export const existsInCache = (key) => !!ModelCache.get(key);
  * @param {function} Model - the model constructor
  * @param {object} options - options object used for fetching that can include:
  *
- *   * attributes {object} - attributes to pass a Model instance
- *   * data {object} - data to pass into the fetch method
+ *   * data {object|object[]} - attributes or models to pass a Model or Collection instance, resp.
+ *   * params {object} - query params to pass into the fetch method
  *   * fetch {boolean} - whether fetch the model after creation
  *   * forceFetch {boolean} - force the fetch to be made if the model is already cached
  *   * method {string} - request type (GET|POST|PUT|DELETE)
- *   * models {array} - models to pass a Collection instance
  *   * options {object} - options to pass to the Model constructor
  *   * prefetch {boolean} - whether the request should be treated as a prefetched resource
  *
@@ -52,24 +51,23 @@ export default (key, Model, options={}) => {
       _promise;
 
   options = {
-    attributes: {},
-    data: {},
+    data: Model && Model.prototype instanceof Collection ? [] : {},
+    params: {},
     fetch: true,
     forceFetch: false,
     method: 'GET',
-    models: [],
     ...options
   };
 
   if (!loadingCache[key]) {
     _promise = new Promise((resolve, reject) => {
       if (!model || options.forceFetch) {
-        model = model || new Model(options[getFirstArgPropertyName(Model)], options.options || {});
+        model = model || new Model(options.data, options.options || {});
 
         if (options.fetch) {
           addToLoadingCache = true;
 
-          model.fetch({data: options.data}).then(
+          model.fetch({params: options.params}).then(
             ([newModel, response]) => {
               delete loadingCache[key];
               ModelCache.put(key, newModel, options.component);
@@ -111,14 +109,3 @@ export default (key, Model, options={}) => {
   // this way we can attach more .then() handlers
   return loadingCache[key];
 };
-
-/**
- * Helper to determine whether to pass the `models` property or the `attributes`
- * value of an options hash as a model instantiation's first argument.
- *
- * @param {Model|Collection} Constructor - model constructor
- * @return {string} property name to pass to model instantiation
- */
-export function getFirstArgPropertyName(Constructor) {
-  return Constructor.prototype instanceof Collection ? 'models' : 'attributes';
-}

--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -33,7 +33,7 @@ const SPREAD_PROVIDES_CHAR = '_';
  *   * noncritical {boolean} - whether the resource should not be taken into
  *        account when determining the loading state of the component. default
  *        is false
- *   * data {object} - data for the fetch call passed to the `request`
+ *   * params {object} - query params for the fetch call passed to the `request`
  *   * options {object} - options object passed to the model's `initialize`
  *   * dependsOn {string[]} - prop fields required to be present before the
  *        resource will fetch
@@ -173,7 +173,7 @@ export const useResources = (getResources, props) => {
           // this is our re-caching: if we already have a new model in the cache that has now been
           // saved (and thus has a real cache key), move the model to the new cache key and remove
           // it from the old one. this will save an unnecessary request.
-          if (prevConfig.attributes && !prevConfig.attributes?.id && config.attributes?.id) {
+          if (prevConfig.data && !prevConfig.data?.id && config.data?.id) {
             ModelCache.put(getCacheKey(config), ModelCache.get(prevCacheKey));
             ModelCache.remove(prevCacheKey);
           }
@@ -407,12 +407,9 @@ function getResourcePropertyName(baseName, modelKey) {
  * @return {Model|Collection} empty model or collection instance with frozen
  *   atributes or models, respectively
  */
-function getEmptyModel({modelKey, attributes, models, options}) {
+function getEmptyModel({modelKey, data, options}) {
   var Model_ = typeof ModelMap[modelKey] === 'function' ? ModelMap[modelKey] : Model,
-      emptyInstance = new Model_(
-        Model_.prototype instanceof Collection ? models : attributes,
-        options
-      );
+      emptyInstance = new Model_(data, options);
 
   // flag to differentiate between other model instances that happen to be empty
   emptyInstance.isEmptyModel = true;
@@ -430,21 +427,21 @@ function getEmptyModel({modelKey, attributes, models, options}) {
  * the constructor's static `cacheFields` array:
  *
  *   `cacheFields` values are taken directly from the config object as opposed
- *   to props, in the following order: `options` object, `attributes` object,
- *   `data` object. Field keys are included in this method, which is why it is
+ *   to props, in the following order: `options` object, `data` object,
+ *   `params` object. Field keys are included in this method, which is why it is
  *   preferred. `cacheFields` entries can be functions, too, which take the
- *   `data` object as a parameter and return a key/value object that gets
+ *   `params` object as a parameter and return a key/value object that gets
  *   flattened to a piece of the cache key.
  *
  * @param {object} config - resource config object (destructured)
  * @return {string} cache key
  */
-export function getCacheKey({modelKey, data={}, options={}, attributes={}}) {
+export function getCacheKey({modelKey, params={}, options={}, data={}}) {
   var toKeyValString = ([key, val]) => val ? `${key}=${val}` : '',
       fields = (ModelMap[modelKey]?.cacheFields || []).map(
         (key) => typeof key === 'function' ?
-          Object.entries(key(data)).map(toKeyValString).join('_') :
-          toKeyValString([key, options[key] || attributes[key] || data[key]])
+          Object.entries(key(params)).map(toKeyValString).join('_') :
+          toKeyValString([key, options[key] || data[key] || params[key]])
       ).filter((x) => x);
 
   return `${modelKey || ''}${fields.sort().join('_')}`;
@@ -621,9 +618,9 @@ function useIsMounted() {
  * before clearing the performance markers.
  *
  * @param {string} name - resource name
- * @param {object<data: object, options: object>} fetch data and options
+ * @param {object<params: object, options: object>} fetch params and options
  */
-function trackRequestTime(name, {data, options}) {
+function trackRequestTime(name, {params, options}) {
   var measurementName = `${name}Fetch`,
       fetchEntry;
 
@@ -634,7 +631,7 @@ function trackRequestTime(name, {data, options}) {
 
     ResourcesConfig.track('API Fetch', {
       Resource: name,
-      data,
+      params,
       options,
       duration: Math.round(fetchEntry.duration)
     });
@@ -808,7 +805,7 @@ function fetchResources(resources, props, {
   return Promise.all(
     // nice visual for this promise chain: http://tinyurl.com/y6wt47b6
     resources.map(([name, config]) => {
-      var {data, modelKey, provides={}, refetch, ...rest} = config,
+      var {params, modelKey, provides={}, refetch, ...rest} = config,
           cacheKey = getCacheKey(config),
           shouldMeasure = shouldMeasureRequest(modelKey, config) && !getModelFromCache(config);
 
@@ -818,7 +815,7 @@ function fetchResources(resources, props, {
 
       return request(cacheKey, ModelMap[modelKey], {
         fetch: !UnfetchedResources.has(modelKey),
-        data,
+        params,
         component,
         forceFetch: refetch,
         ...rest
@@ -840,13 +837,10 @@ function fetchResources(resources, props, {
                 // components may be listening to existing models, so only create
                 // new model if one does not currently exist
                 existingModel ?
-                  existingModel.set(uConfig.models || uConfig.attributes) :
+                  existingModel.set(uConfig.data) :
                   ModelCache.put(
                     uCacheKey,
-                    new ModelMap[uConfig.modelKey](
-                      uConfig.models || uConfig.attributes,
-                      uConfig.options || {}
-                    ),
+                    new ModelMap[uConfig.modelKey](uConfig.data, uConfig.options || {}),
                     component
                   );
               }

--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -34,7 +34,7 @@ const SPREAD_PROVIDES_CHAR = '_';
  *        account when determining the loading state of the component. default
  *        is false
  *   * params {object} - query params for the fetch call passed to the `request`
- *   * options {object} - options object passed to the model's `initialize`
+ *   * options {object} - instance properties set on the model (which are not data)
  *   * dependsOn {string[]} - prop fields required to be present before the
  *        resource will fetch
  *   * provides {object<string: function>[]} - list of props that a resource
@@ -618,7 +618,7 @@ function useIsMounted() {
  * before clearing the performance markers.
  *
  * @param {string} name - resource name
- * @param {object<params: object, options: object>} fetch params and options
+ * @param {object<params: object, options: object>} fetch params and props
  */
 function trackRequestTime(name, {params, options}) {
   var measurementName = `${name}Fetch`,
@@ -840,7 +840,7 @@ function fetchResources(resources, props, {
                   existingModel.set(uConfig.data) :
                   ModelCache.put(
                     uCacheKey,
-                    new ModelMap[uConfig.modelKey](uConfig.data, uConfig.options || {}),
+                    new ModelMap[uConfig.modelKey](uConfig.data, uConfig.options),
                     component
                   );
               }

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -8,8 +8,8 @@ var prefilter = (x) => x;
 
 /**
  * The basic sync function, which does very little other than prep the options argument sent to the
- * ajax function. It basically sets up defaults, seeding the query data if not explicitly specified
- * already. It also finds the base url or throws if one does not exist.
+ * ajax function. It basically sets up defaults, seeding the query params if not explicitly
+ * specified already. It also finds the base url or throws if one does not exist.
  *
  * @param {Model|Collection} model - model making API request
  * @param {object} options - generic map of request options
@@ -21,8 +21,8 @@ export default function(model, options={}) {
     contentType: MIME_TYPE_JSON,
     // url can be passed via the model (as a property or function) or via options.url directly
     ...!options.url ? {url: result(model, 'url') || urlError()} : {},
-    ...!options.data && ['POST', 'PATCH', 'PUT'].includes(options.method) ?
-      {data: options.attrs || model.toJSON()} :
+    ...!options.params && ['POST', 'PATCH', 'PUT'].includes(options.method) ?
+      {params: options.attrs || model.toJSON()} :
       {},
     // default catch block. most large applications should override this in the config settings to
     // provide support for things like 401s or 429s.
@@ -38,7 +38,8 @@ export default function(model, options={}) {
  * @param {object} options - map of request options:
  *   * url {string} - this is required, but will be present automatically if not passed directly in
  *     the sync method's request object
- *   * data {object} - will be url-stringified for GET requests and JSON-stringified for POST bodies
+ *   * params {object} - will be url-stringified for GET requests and JSON-stringified for POST
+ *     bodies
  *   * headers {object} - map of headers to their values
  *   * contentType {string} value of content type header, which will also determine how the POST
  *     bodies are assembled
@@ -48,12 +49,12 @@ export default function(model, options={}) {
  *   rejects with the response
  */
 export function ajax(options) {
-  var hasData = !!Object.keys(options.data || {}).length,
-      hasBodyContent = !/^(?:GET|HEAD)$/.test(options.method) && hasData;
+  var hasParams = !!Object.keys(options.params || {}).length,
+      hasBodyContent = !/^(?:GET|HEAD)$/.test(options.method) && hasParams;
 
-  if (options.method === 'GET' && hasData) {
+  if (options.method === 'GET' && hasParams) {
     options.url += (options.url.indexOf('?') > -1 ? '&' : '?') +
-      ResourcesConfig.stringify(options.data, options);
+      ResourcesConfig.stringify(options.params, options);
   }
 
   options = {...options, ...prefilter(options)};
@@ -62,17 +63,17 @@ export function ajax(options) {
     ...options,
     headers: {
       Accept: MIME_TYPE_JSON,
-      // only set contentType header if a write request and if there is body data. also, default to
-      // JSON contentTypes, but allow for it to be overridden, ie with x-www-form-urlencoded.
+      // only set contentType header if a write request and if there is body params. also, default
+      // to JSON contentTypes, but allow for it to be overridden, ie with x-www-form-urlencoded.
       ...hasBodyContent ? {'Content-Type': options.contentType} : {},
       ...options.headers
     },
     ...hasBodyContent ? {
-      body: typeof options.data === 'string' ?
-        options.data :
+      body: typeof options.params === 'string' ?
+        options.params :
         options.contentType === MIME_TYPE_JSON ?
-          JSON.stringify(options.data) :
-          ResourcesConfig.stringify(options.data, options)
+          JSON.stringify(options.params) :
+          ResourcesConfig.stringify(options.params, options)
     } : {}
   // catch block here handles the case where the response isn't valid json,
   // like for example a 204 no content

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -20,7 +20,7 @@ export default function(model, options={}) {
   return ajax({
     contentType: MIME_TYPE_JSON,
     // url can be passed via the model (as a property or function) or via options.url directly
-    ...!options.url ? {url: result(model, 'url') || urlError()} : {},
+    ...!options.url ? {url: result(model, 'url', model.urlOptions) || urlError()} : {},
     ...!options.params && ['POST', 'PATCH', 'PUT'].includes(options.method) ?
       {params: options.attrs || model.toJSON()} :
       {},

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -215,6 +215,6 @@ export function sortBy(list=[], comparator) {
  * @param {any} prop - property of object to evaluate
  * @return {any} evaluated value of object at property
  */
-export function result(obj={}, prop) {
-  return typeof obj[prop] === 'function' ? obj[prop]() : obj[prop];
+export function result(obj={}, prop, ...args) {
+  return typeof obj[prop] === 'function' ? obj[prop](...args) : obj[prop];
 }

--- a/test/collection.test.js
+++ b/test/collection.test.js
@@ -43,6 +43,13 @@ describe('Collection', () => {
     expect(collection.Model).toEqual(__Model);
   });
 
+  it('unreserved option items are assigned to a `urlOptions` instance property', () => {
+    collection = new Collection([], {one: 1, two: 2, comparator: 'foo', parse: true});
+
+    expect(collection.urlOptions).toEqual({one: 1, two: 2});
+    expect(collection.toJSON()).toEqual([]);
+  });
+
   it('adds any models passed to its models list', () => {
     var model1 = new Model,
         model2 = new Model;

--- a/test/model-mocks.js
+++ b/test/model-mocks.js
@@ -65,7 +65,7 @@ export class SearchQueryModel extends Model {
     options = {
       ...options,
       contentType: 'application/json',
-      data: JSON.stringify(options.data),
+      params: JSON.stringify(options.params),
       type: 'POST'
     };
 

--- a/test/model-mocks.js
+++ b/test/model-mocks.js
@@ -4,11 +4,10 @@ import Model from '../lib/model';
 export class UserModel extends Model {
   key = 'user'
 
-  constructor(attrs, options={}) {
-    super(attrs, options);
+  constructor(attributes, options={}) {
+    super(attributes, options);
 
     this.userId = options.userId;
-    this.fraudLevel = options.fraudLevel;
   }
 
   url() {
@@ -39,14 +38,8 @@ export class DecisionsCollection extends Collection {
 export class NotesModel extends Model {
   key = 'notes'
 
-  constructor(attributes, options={}) {
-    super(attributes, options);
-
-    this.userId = options.userId;
-  }
-
-  url() {
-    return `/root/${this.userId}/notes`;
+  url({userId}) {
+    return `/root/${userId}/notes`;
   }
 
   static cacheFields = ['userId']
@@ -54,12 +47,6 @@ export class NotesModel extends Model {
 
 export class SearchQueryModel extends Model {
   key = 'search'
-
-  constructor(attributes, options={}) {
-    super(attributes, options);
-
-    this.userId = options.userId;
-  }
 
   fetch(options={}) {
     options = {
@@ -117,13 +104,7 @@ export class LabelInstanceModel extends Model {
 export class AccountConfigModel extends Model {
   key = 'accountConfig'
 
-  constructor(attrs, options={}) {
-    super(attrs, options);
-
-    this.accountId = options.accountId;
-  }
-
-  url() {
-    return `/root/accounts/${this.accountId}/config`;
+  url({accountId}) {
+    return `/root/accounts/${accountId}/config`;
   }
 }

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -64,6 +64,12 @@ describe('Model', () => {
     expect(model.toJSON()).toEqual({});
   });
 
+  it('unreserved option items are assigned to a `urlOptions` instance property', () => {
+    model = new Model({}, {one: 1, two: 2, parse: true, silent: true});
+
+    expect(model.urlOptions).toEqual({one: 1, two: 2});
+  });
+
   it('can optionally have defaults that are a function', () => {
     class _Model extends Model {
       static defaults = {one: 1, two: 2}
@@ -469,6 +475,22 @@ describe('Model', () => {
       collection.url = () => '/library';
       model = new _Model({name: 'noah?grant'}, {collection});
       expect(model.url()).toEqual('/library/noah%3Fgrant');
+    });
+
+    it('is called by default with its urlOptions', () => {
+      class _Model extends Model {
+        urlRoot({section}) {
+          return `/library/${section}`;
+        }
+      }
+
+      model = new _Model({}, {section: 'nature'});
+      expect(model.url()).toEqual('/library/nature');
+
+      collection = new Collection();
+      collection.url = ({section}) => `/library/${section}`;
+      model = new Model({}, {collection, section: 'history'});
+      expect(model.url()).toEqual('/library/history');
     });
   });
 

--- a/test/prefetch.test.js
+++ b/test/prefetch.test.js
@@ -8,7 +8,7 @@ import ReactDOM from 'react-dom';
 const renderNode = document.createElement('div');
 const getResources = ({DECISIONS, USER}, props) => ({
   [USER]: {
-    data: {home: props.home, source: props.source},
+    params: {home: props.home, source: props.source},
     options: {userId: props.userId}
   },
   [DECISIONS]: {}
@@ -30,7 +30,7 @@ describe('prefetch', () => {
     jest.useRealTimers();
   });
 
-  it('correctly turns the config object into cache key, data, and options', () => {
+  it('correctly turns the config object into cache key, params, and options', () => {
     var oldFields = UserModel.cacheFields;
 
     UserModel.cacheFields = ['userId', 'source'];
@@ -42,7 +42,7 @@ describe('prefetch', () => {
     expect(Request.default.mock.calls[0][1]).toEqual(UserModel);
     expect(Request.default.mock.calls[0][2]).toEqual({
       options: {userId: 'noah'},
-      data: {home: 'sf', source: 'hbase'},
+      params: {home: 'sf', source: 'hbase'},
       prefetch: true
     });
 

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -1,6 +1,5 @@
-import request, {existsInCache, getFirstArgPropertyName, getFromCache} from '../lib/request';
+import request, {existsInCache, getFromCache} from '../lib/request';
 
-import Collection from '../lib/collection';
 import Model from '../lib/model';
 import ModelCache from '../lib/model-cache';
 import {waitsFor} from './test-utils';
@@ -301,15 +300,6 @@ describe('Request', () => {
       expect(existsInCache('foo')).toBe(true);
       expect(getFromCache('foo')).toEqual(model);
       expect(getFromCache('bar')).not.toBeDefined();
-    });
-  });
-
-  describe('getFirstArgPropertyName', () => {
-    it('returns \'models\' for a collection, \'attributes\' for a model', () => {
-      class _Collection extends Collection {}
-      class _Model extends Model {}
-      expect(getFirstArgPropertyName(_Collection)).toEqual('models');
-      expect(getFirstArgPropertyName(_Model)).toEqual('attributes');
     });
   });
 });

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -28,7 +28,7 @@ describe('Request', () => {
         });
       }
 
-      return Promise.resolve([new Model(), '', {response: {status: 200}}]);
+      return Promise.resolve([this, {status: 200}]);
     });
 
     jest.spyOn(ModelCache, 'put');
@@ -53,7 +53,7 @@ describe('Request', () => {
   describe('when using the default exported function', () => {
     it('returns a promise if the model does not exist', async() => {
       var model,
-          promise = request('foo', Model, {component}).then(([_model]) => {
+          promise = request('foo', Model, {options: {one: 1}, component}).then(([_model]) => {
             model = _model;
           });
 
@@ -62,6 +62,8 @@ describe('Request', () => {
       expect(promise instanceof Promise).toBe(true);
       // in this instance we're resolving immediately, so model should be Model
       expect(model instanceof Model).toBe(true);
+      // this tests that it properly passes along the options object to the model constructor
+      expect(model.urlOptions).toEqual({one: 1});
     });
 
     describe('if the model does exist', () => {

--- a/test/sync.test.js
+++ b/test/sync.test.js
@@ -35,50 +35,50 @@ describe('sync', () => {
 
     expect(window.fetch.mock.calls[0][0]).toEqual('/library');
     expect(window.fetch.mock.calls[0][1].method).toEqual('GET');
-    expect(window.fetch.mock.calls[0][1].data).not.toBeDefined();
+    expect(window.fetch.mock.calls[0][1].params).not.toBeDefined();
     window.fetch.mockClear();
 
-    await library.fetch({data: {one: 'two'}});
+    await library.fetch({params: {one: 'two'}});
     expect(window.fetch.mock.calls[0][0]).toEqual('/library?one=two');
     expect(window.fetch.mock.calls[0][1].method).toEqual('GET');
-    expect(window.fetch.mock.calls[0][1].data).toEqual({one: 'two'});
+    expect(window.fetch.mock.calls[0][1].params).toEqual({one: 'two'});
     window.fetch.mockClear();
 
-    await library.fetch({url: '/library?one=two', data: {two: 'three'}});
+    await library.fetch({url: '/library?one=two', params: {two: 'three'}});
     expect(window.fetch.mock.calls[0][0]).toEqual('/library?one=two&two=three');
     expect(window.fetch.mock.calls[0][1].method).toEqual('GET');
-    expect(window.fetch.mock.calls[0][1].data).toEqual({two: 'three'});
+    expect(window.fetch.mock.calls[0][1].params).toEqual({two: 'three'});
     window.fetch.mockClear();
 
     // safe call with no options, even though this won't work
     expect(async() => sync(library)).not.toThrow();
     expect(window.fetch.mock.calls[0][0]).toEqual('/library');
     expect(window.fetch.mock.calls[0][1].method).not.toBeDefined();
-    expect(window.fetch.mock.calls[0][1].data).not.toBeDefined();
+    expect(window.fetch.mock.calls[0][1].params).not.toBeDefined();
   });
 
-  it('passing data', async() => {
+  it('passing params', async() => {
     // GET
-    await library.fetch({data: {a: 'a', one: 1}});
+    await library.fetch({params: {a: 'a', one: 1}});
 
     expect(window.fetch.mock.calls[0][0]).toEqual('/library?a=a&one=1');
     window.fetch.mockClear();
 
     // with body content: already stringified
-    await library.add(attrs).at(0).save(null, {data: 'somestring'});
+    await library.add(attrs).at(0).save(null, {params: 'somestring'});
 
     expect(window.fetch.mock.calls[0][0]).toEqual('/library');
     expect(window.fetch.mock.calls[0][1].body).toEqual('somestring');
     window.fetch.mockClear();
 
     // with body content: as JSON
-    await library.at(0).save(null, {data: {a: 'a', one: 1}});
+    await library.at(0).save(null, {params: {a: 'a', one: 1}});
     expect(window.fetch.mock.calls[0][0]).toEqual('/library');
     expect(window.fetch.mock.calls[0][1].body).toEqual(JSON.stringify({a: 'a', one: 1}));
     window.fetch.mockClear();
 
     // with body content: not as json
-    await library.at(0).save(null, {data: {a: 'a', one: 1}, contentType: 'resourcerer/json'});
+    await library.at(0).save(null, {params: {a: 'a', one: 1}, contentType: 'resourcerer/json'});
     expect(window.fetch.mock.calls[0][0]).toEqual('/library');
     expect(window.fetch.mock.calls[0][1].body).toEqual('a=a&one=1');
   });
@@ -88,7 +88,7 @@ describe('sync', () => {
 
     expect(window.fetch.mock.calls[0][0]).toEqual('/library');
     expect(window.fetch.mock.calls[0][1].method).toEqual('POST');
-    expect(window.fetch.mock.calls[0][1].data).toEqual({
+    expect(window.fetch.mock.calls[0][1].params).toEqual({
       title: 'The Tempest',
       author: 'Bill Shakespeare',
       length: 123
@@ -101,7 +101,7 @@ describe('sync', () => {
 
     expect(window.fetch.mock.calls[0][0]).toEqual('/library/1-the-tempest');
     expect(window.fetch.mock.calls[0][1].method).toEqual('PUT');
-    expect(window.fetch.mock.calls[0][1].data).toEqual({
+    expect(window.fetch.mock.calls[0][1].params).toEqual({
       id: '1-the-tempest',
       title: 'The Tempest',
       author: 'William Shakespeare',
@@ -116,7 +116,7 @@ describe('sync', () => {
 
     expect(window.fetch.mock.calls[1][0]).toEqual('/library/2-the-tempest');
     expect(window.fetch.mock.calls[1][1].method).toEqual('GET');
-    expect(window.fetch.mock.calls[1][1].data).not.toBeDefined();
+    expect(window.fetch.mock.calls[1][1].params).not.toBeDefined();
   });
 
   it('destroy', async() => {
@@ -126,7 +126,7 @@ describe('sync', () => {
 
     expect(window.fetch.mock.calls[1][0]).toEqual('/library/2-the-tempest');
     expect(window.fetch.mock.calls[1][1].method).toEqual('DELETE');
-    expect(window.fetch.mock.calls[1][1].data).not.toBeDefined();
+    expect(window.fetch.mock.calls[1][1].params).not.toBeDefined();
   });
 
   it('rejects non-2xx', async() => {

--- a/test/sync.test.js
+++ b/test/sync.test.js
@@ -83,6 +83,40 @@ describe('sync', () => {
     expect(window.fetch.mock.calls[0][1].body).toEqual('a=a&one=1');
   });
 
+  it('passes urlOptions to the model to formulate the url path', async() => {
+    var librarySectionBook;
+
+    class LibrarySection extends Collection {
+      url({section}) {
+        return `/library/${section}`;
+      }
+    }
+
+    class LibrarySectionBook extends Model {
+      url({section, bookId}) {
+        return `/library/${section}/${bookId}`;
+      }
+    }
+
+    library = new LibrarySection([], {section: 'nature'});
+    await library.fetch({params: {a: 'a', one: 1}});
+
+    expect(window.fetch.mock.calls[0][0]).toEqual('/library/nature?a=a&one=1');
+    // safe
+    library = new LibrarySection();
+    await library.fetch({params: {a: 'a', one: 1}});
+    expect(window.fetch.mock.calls[1][0]).toEqual('/library/undefined?a=a&one=1');
+
+    librarySectionBook = new LibrarySectionBook({}, {section: 'nature', bookId: 'all-about-frogs'});
+    await librarySectionBook.fetch({params: {a: 'a', one: 1}});
+    expect(window.fetch.mock.calls[2][0]).toEqual('/library/nature/all-about-frogs?a=a&one=1');
+
+    // safe
+    librarySectionBook = new LibrarySectionBook();
+    await librarySectionBook.fetch({params: {a: 'a', one: 1}});
+    expect(window.fetch.mock.calls[3][0]).toEqual('/library/undefined/undefined?a=a&one=1');
+  });
+
   it('create', async() => {
     await library.create(attrs, {wait: false});
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -190,6 +190,7 @@ describe('Utils', () => {
   describe('result', () => {
     it('returns the correct value if a function', () => {
       expect(result({foo: () => 'bar'}, 'foo')).toEqual('bar');
+      expect(result({foo: (x, y) => x + y + 5}, 'foo', 10, 5)).toEqual(20);
     });
 
     it('returns the correct value if not a function', () => {


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
- Helps make resourcerer configs less confusing by changing the `data` property to be `params`, since they represent query (or body) parameters. the `attributes` property becomes the `data` property.
- Additionally, properties from the `options` object in the resource config now get passed directly to a model's/collection's `url` method for constructing the url, obviating the need to set instance properties.
