### PR TITLE
prefetched resources should be independent

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,6 +24,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci && npm i react@16 react-dom@16
+    - run: npm ci && npm i react@17 react-dom@17
     - run: npm run lint
     - run: npm test

--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -684,7 +684,10 @@ function modelAggregator(resources) {
 
 /**
  * Separates out resources between those that are loading and those that have loaded. The latter
- * won't need to get passed to fetchResources, but the former will.
+ * won't need to get passed to fetchResources, but the former will. Make sure that prefetched
+ * resources get added to those that are loading so that the request gets made. Since prefetched
+ * models don't factor into loading states, there's no concern that they get passed to
+ * fetchResources even if they have been cached.
  *
  * @param {array[]} resourcesToUpdate - resource configs to partition
  * @param {object} loadingStates - contains upcoming loading states for each resource
@@ -693,7 +696,7 @@ function modelAggregator(resources) {
  */
 function partitionResources(resourcesToUpdate, loadingStates) {
   return resourcesToUpdate.reduce((memo, [name, config]) =>
-    config.refetch || !hasLoaded(loadingStates[getResourceState(name)]) ?
+    config.refetch || config.prefetch || !hasLoaded(loadingStates[getResourceState(name)]) ?
       [memo[0], memo[1].concat([[name, config]])] :
       [memo[0].concat([[name, config]]), memo[1]],
   [[], []]);

--- a/test/use-resources.test.jsx
+++ b/test/use-resources.test.jsx
@@ -962,12 +962,24 @@ describe('useResources', () => {
 
         // should have two search query calls, but the props on searchQueryModel
         // should have from = 0
-        expect(requestSpy.mock.calls
-            .map((call) => call[0])
-            .filter((key) => /^searchQuery/.test(key)).length).toEqual(2);
+        expect(
+          requestSpy.mock.calls.filter((call) => /^searchQuery/.test(call[0]))
+              .map((call) => call[0])
+        ).toEqual(['searchQuery', 'searchQueryfrom=10']);
 
         await waitsFor(() => dataChild.props.hasLoaded);
         expect(dataChild.props.searchQueryModel.data).toEqual('{"from":0}');
+
+        // move to the next page
+        dataChild.props.setResourceState({page: 10});
+
+        await waitsFor(() => requestSpy.mock.calls.length === 6);
+        expect(
+          requestSpy.mock.calls.filter((call) => /^searchQuery/.test(call[0]))
+              .map((call) => call[0])
+        ).toEqual(['searchQuery', 'searchQueryfrom=10', 'searchQueryfrom=20']);
+
+        expect(dataChild.props.searchQueryModel.data).toEqual('{"from":10}');
       });
 
       it('that are not taken into account for component loading states', async() => {

--- a/test/with-resources.test.jsx
+++ b/test/with-resources.test.jsx
@@ -988,12 +988,24 @@ describe('withResources', () => {
 
         // should have two search query calls, but the props on searchQueryModel
         // should have from = 0
-        expect(requestSpy.mock.calls
-            .map((call) => call[0])
-            .filter((key) => /^searchQuery/.test(key)).length).toEqual(2);
+        expect(
+          requestSpy.mock.calls.filter((call) => /^searchQuery/.test(call[0]))
+              .map((call) => call[0])
+        ).toEqual(['searchQuery', 'searchQueryfrom=10']);
 
         await waitsFor(() => dataChild.props.hasLoaded);
         expect(dataChild.props.searchQueryModel.data).toEqual('{"from":0}');
+
+        // move to the next page
+        dataChild.props.setResourceState({page: 10});
+
+        await waitsFor(() => requestSpy.mock.calls.length === 6);
+        expect(
+          requestSpy.mock.calls.filter((call) => /^searchQuery/.test(call[0]))
+              .map((call) => call[0])
+        ).toEqual(['searchQuery', 'searchQueryfrom=10', 'searchQueryfrom=20']);
+
+        expect(dataChild.props.searchQueryModel.data).toEqual('{"from":10}');
       });
 
       it('that are not taken into account for component loading states', async() => {


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
A bug where the prefetch only happens when its non-prefetch counterpart also needs to be fetched.

## Description of Proposed Changes:  
  -  The partition between loaded and not-yet loaded resources should return prefetched resources into the 'not-yet' loaded camp, since even if it is actually cached, we won't be using its loading state and model state, anyway.
 
