### PR TITLE
static modelIdAttribute instead of modelId fn

### DIFF
--- a/docs/collection.md
+++ b/docs/collection.md
@@ -46,6 +46,16 @@ This property tells resourcerer how to determine whether to make a new request o
 
 A boolean or function that accepts a [resource configuration object](https://github.com/noahgrant/resourcerer#nomenclature) and returns a boolean, telling resourcerer to track this collection's request time and report it via the `track` method setup in [configuration](https://github.com/noahgrant/resourcerer#configuring-resourcerer).
 
+### `static` modelIdAttribute
+
+Use this as a shortcut when you don't want to define a custom Model class just because the collection doesn't contain the default id field (which is `'id'`), ie:
+
+```js
+// the collection will index its models based on the `name` property instead of the default `id` property
+static modelIdAttribute = 'name'
+``` 
+
+
 
 ## Methods
 
@@ -106,7 +116,7 @@ This is the method that `resourcerer` uses internally to get server data and set
 get: Model? (identifier: string|number)
 ```
 
-Collections index their Model instances by either the Model's [`idAttribute`](/docs/model.md#static-idattribute) or by the return value of its [`modelId`](#modelid) method. The `.get()` method takes an id value and returns the quick-lookup model instance if one exists.  
+Collections index their Model instances by either the Model's [`idAttribute`](/docs/model.md#static-idattribute) or, equivalently as a shortcut, by the collection's own static [`modelIdAttribute`](#static-modelidattribute) property. The `.get()` method takes an id value and returns the quick-lookup model instance if one exists.  
 
 ### has  
 ```js
@@ -114,20 +124,6 @@ has: boolean (identifier: string|number|Model|object)
 ```
 
 Returns whether or not a model exists in a collection. You can pass the model instance itself, a model's data, or a model's id.
-
-### modelId
-```js
-modelId: number|string (attrs: Object)
-```
-
-Use this as a shortcut when you don't want to define a custom Model class just because the collection doesn't contain the default id field (which is `'id'`). By default this is equal to the [`idAttribute`](/docs/model.md#static-idattribute) set on the collection's Model class. But if you don't want to add that, you can use this method, ie:
-
-```js
-// the collection will index its models based on the `name` property instead of the default `id` property
-modelId(attrs) {
-  return attrs.name;
-}
-``` 
 
 ### parse
 ```js

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -30,7 +30,7 @@ export default class Collection {
   constructor(models, options={}) {
     const RESERVED_OPTION_KEYS = ['Model', 'comparator', 'silent', 'parse'];
 
-    this.Model = options.Model || this.constructor.Model;
+    this.Model = options.Model || this._getModelClass();
     this.comparator = options.comparator || this.constructor.comparator;
 
     this._reset();
@@ -52,6 +52,13 @@ export default class Collection {
    * custom Model subclass.
    */
   static Model = Model
+
+  /**
+   * Defines the property by which we can uniquely identify models in the collection. Override this
+   * if you're not defining your own custom Model class but still need to index by a different field
+   * than the default ('id').
+   */
+  static modelIdAttribute = null
 
   /**
    * This is a list of keys (could be attribute keys, but also keys passed in from the options
@@ -218,7 +225,7 @@ export default class Collection {
     }
 
     return this._byId[obj] ||
-      this._byId[this.modelId(this._isModel(obj) ? obj.attributes : obj)] ||
+      this._byId[(this._isModel(obj) ? obj.attributes : obj)[this.Model.idAttribute]] ||
       obj.cid && this._byId[obj.cid];
   }
 
@@ -417,14 +424,24 @@ export default class Collection {
   }
 
   /**
-   * Defines how to uniquely identify models in the collection, which defaults to looking up a
-   * model's idAttribute (which itself defaults to 'id').
+   * This function gets called when the collection is instantiated, and its return value is set to
+   * its Model property (and used to instantiate all its models). It's only used if a `Model`
+   * option isn't passed to the constructor, and by default it returns the Model base class. But
+   * if the collection has a `modelIdAttribute` static property, it will create a new Model class
+   * with the corresponding `idAttribute` property and return that.
    *
-   * @param {object} attrs - a model's data attribute
-   * @return {string} that model's unique identifier
+   * @return {Model} model class associated with the collection
    */
-  modelId(attrs) {
-    return attrs[this.Model.idAttribute];
+  _getModelClass() {
+    if (this.constructor.modelIdAttribute) {
+      let attr = this.constructor.modelIdAttribute;
+
+      return class extends Model {
+        static idAttribute = attr
+      };
+    }
+
+    return this.constructor.Model;
   }
 
   /**
@@ -482,8 +499,8 @@ export default class Collection {
 
       delete this._byId[model.cid];
 
-      if (this.modelId(model.attributes)) {
-        delete this._byId[this.modelId(model.attributes)];
+      if (model.attributes[this.Model.idAttribute]) {
+        delete this._byId[model.attributes[this.Model.idAttribute]];
       }
 
       removed.push(model);
@@ -514,7 +531,7 @@ export default class Collection {
   _addReference(model) {
     this._byId[model.cid] = model;
 
-    let id = this.modelId(model.attributes);
+    let id = model.attributes[this.Model.idAttribute];
 
     if (id || typeof id === 'number') {
       this._byId[id] = model;
@@ -533,7 +550,7 @@ export default class Collection {
   _removeReference(model) {
     delete this._byId[model.cid];
 
-    let id = this.modelId(model.attributes);
+    let id = model.attributes[this.Model.idAttribute];
 
     if (id) {
       delete this._byId[id];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "1.0.0-beta-4",
+  "version": "1.0.0-beta-5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "1.0.0-beta-4",
+      "version": "1.0.0-beta-5",
       "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.0-beta-4",
+  "version": "1.0.0-beta-5",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/collection.test.js
+++ b/test/collection.test.js
@@ -617,21 +617,39 @@ describe('Collection', () => {
     });
   });
 
-  describe('modelId', () => {
-    it('returns the value at the id attribute of a set of attributes', () => {
+  describe('setting a model id attribute', () => {
+    it('on the model sets the id attributes for all models', () => {
       class _Model extends Model {
         static idAttribute = 'name'
       }
 
+      // default is just id
+      collection = new Collection();
+      collection.add({id: 'noahgrant', name: 'Noah Grant'});
+      expect(collection.get('noahgrant')).toBeDefined();
+      expect(collection.get('Noah Grant')).not.toBeDefined();
+      expect(collection.get('noahgrant').id).toEqual('noahgrant');
+      expect(collection.Model.idAttribute).toEqual('id');
+
+      collection = new Collection([], {Model: _Model});
+      collection.add({id: 'noahgrant', name: 'Noah Grant'});
+      expect(collection.get('noahgrant')).not.toBeDefined();
+      expect(collection.get('Noah Grant')).toBeDefined();
+      expect(collection.get('Noah Grant').id).toEqual('Noah Grant');
+      expect(collection.Model.idAttribute).toEqual('name');
+    });
+
+    it('on the collection sets the id attribute for its models', () => {
       class _Collection extends Collection {
-        static Model = _Model
+        static modelIdAttribute = 'name'
       }
 
-      collection = new Collection();
-      expect(collection.modelId({id: 'noahgrant', name: 'Noah Grant'})).toEqual('noahgrant');
-
       collection = new _Collection();
-      expect(collection.modelId({id: 'noahgrant', name: 'Noah Grant'})).toEqual('Noah Grant');
+      collection.add({id: 'noahgrant', name: 'Noah Grant'});
+      expect(collection.get('noahgrant')).not.toBeDefined();
+      expect(collection.get('Noah Grant')).toBeDefined();
+      expect(collection.get('Noah Grant').id).toEqual('Noah Grant');
+      expect(collection.Model.idAttribute).toEqual('name');
     });
   });
 


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

The Collection's [modelId](https://github.com/noahgrant/resourcerer/blob/aad8ece1ae58f29a2d64df5ae53302be735498e8/docs/collection.md#modelid) method is flawed, because it doesn't actually set the underlying `idAttribute` of the model itself, which means that the collection might be indexed correctly, but the `model.id` property will not be set correctly. The utility of the `modelId` method was to obviate the need to create a new model class just to give it a new `idAttribute` class. Instead this shortcut has been given to the static collection property `modelIdAttribute`, which will index the collection correctly _and_ set the models' id properties.

## Description of Proposed Changes:  
  -  if the `static modelIdAttribute` property exists on a collection, then when the collection is instantiated a new model class is created automatically with the `idAttribute` set and the result is set to the `this.Model` property.
  -  the `modelId` instance method has been removed.
 
