### PR TITLE
add lazy fetch option

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -54,19 +54,22 @@ export default (key, Model, options={}) => {
     data: Model && Model.prototype instanceof Collection ? [] : {},
     params: {},
     options: {},
-    fetch: true,
+    fetch: !options.lazy,
     force: false,
+    lazy: false,
     method: 'GET',
     ...options
   };
 
   if (!loadingCache[key]) {
     _promise = new Promise((resolve, reject) => {
-      if (!model || options.force) {
+      if (!model || model.lazy || options.force) {
         model = model || new Model(options.data, options.options);
 
         if (options.fetch) {
           addToLoadingCache = true;
+
+          delete model.lazy;
 
           model.fetch({params: options.params}).then(
             ([newModel, response]) => {
@@ -80,6 +83,10 @@ export default (key, Model, options={}) => {
             }
           );
         } else {
+          // lazy means resolove but don't fetch yet; it will get updates from other components
+          // we only want to do this if a model is not yet in the cache
+          options.lazy && !ModelCache.get(key) ? model.lazy = true : null;
+
           ModelCache.put(key, model, options.component);
           resolve([model]);
         }


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

This adds a `lazy` flag for a resource configuration object that allows a component to read and listen on changes to a resources without actually fetching that resource. This is for an uncommon case where you might have a collection of results from one source (say, a search index) and a detail view of an item in that collection from another source (your database). In such a case you can read from your collection (search), but responding to an update from the detail model view is not possible. The lazy option would allow another component to do the actual resource fetching (in the detail view), but both are still linked by the same model and would respond to updates.

Undocumented for now, is a noop without using the `lazy` flag.

## Description of Proposed Changes:  
  -  Adds a `lazy` model property in our request module if the resource is requested with a `lazy: true` flag and has not already been put in the cache. Any following non-lazy request does the actual fetching and removes the `lazy` property.
