### PR TITLE
do not depend on lazy for default fetch value

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -54,7 +54,7 @@ export default (key, Model, options={}) => {
     data: Model && Model.prototype instanceof Collection ? [] : {},
     params: {},
     options: {},
-    fetch: !options.lazy,
+    fetch: true,
     force: false,
     lazy: false,
     method: 'GET',
@@ -66,7 +66,7 @@ export default (key, Model, options={}) => {
       if (!model || model.lazy || options.force) {
         model = model || new Model(options.data, options.options);
 
-        if (options.fetch) {
+        if (options.fetch && !options.lazy) {
           addToLoadingCache = true;
 
           delete model.lazy;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

Bug with #114 where `options.fetch` has a default value that depends on `options.lazy`. But `fetch` gets passed in by `useResources`, so we should consider each independent.

## Description of Proposed Changes:  
  -  Removes `options.lazy` default value for `options.fetch` and does not fetch unless `fetch` is true _and_ `lazy` is false

