### PR TITLE
use option.attrs for deferred attribute setting

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -240,10 +240,7 @@ export default class Model {
     if (!options.wait) {
       this.set(attrs, options);
     } else {
-      // sneaky: this will show up at this point if you .toJSON(), but it will not
-      // be associated with an update. this is so that in the sync method, they can get all
-      // attributes via .toJSON()
-      this.attributes = {...this.attributes, ...attrs};
+      options.attrs = {...this.attributes, ...attrs};
     }
 
     options.method = this.isNew() ? 'POST' : options.patch ? 'PATCH' : 'PUT';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -314,7 +314,7 @@ describe('Model', () => {
 
       result = model.save({three: 'three'}, {wait: true});
       expect(callback).not.toHaveBeenCalled();
-      expect(model.toJSON()).toEqual({one: 'one', three: 'three'});
+      expect(model.toJSON()).toEqual({one: 'one'});
 
       await result;
 


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

Setting attributes on the model defeats the purpose of deferring the set call with `wait: true`. Normally this would be used along with a state change in your component to show a loader. But that state change would render the latest model attributes, anyway.


## Description of Proposed Changes:  
  -  Instead of setting deferred attributes on the model, add them to `options.attrs` before calling the `sync` method

