### PR TITLE
consider it a model to update if lazy

### DIFF
--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -499,19 +499,20 @@ function findCacheKey(resource, getResources, props) {
  * @param {object} props - current component props
  * @param {LoadingStates} defaultState - state to return if resource already exists in cache;
  *   in most circumstances, this should be the LOADED state as you might expect. However, when we
- *   prep resources to be re-fetched, in order to keep the loading state in sync with its model
- *   state, even a cached resource should be temporarily in a LOADING state (if cached, this will
- *   be corrected in the next microtask and before the JS stack is completed, so the LOADING state
- *   should never be shown in the UI, despite render being called multiple times).
+ *   prep resources to be re-fetched or if models were previously created lazily (without fetching),
+ *   in order to keep the loading state in sync with its model state, even a cached resource should
+ *   be temporarily in a LOADING state (if cached, this will be corrected in the next microtask and
+ *   before the JS stack is completed, so the LOADING state should never be shown in the UI, despite
+ *   render being called multiple times).
  * @return {object} state object with resource state keys as keys and the loading
  *    state as values
  */
 function buildResourcesLoadingState(resources, props, defaultState=LoadingStates.LOADED) {
   return resources.reduce((state, [name, config]) => Object.assign(state, {
-    [getResourceState(name)]:
-      !config.refetch && (shouldBypassFetch(props, [name, config]) || getModelFromCache(config)) ?
-        defaultState :
-        (!hasAllDependencies(props, [, config]) ? LoadingStates.PENDING : LoadingStates.LOADING)
+    [getResourceState(name)]: !config.refetch && (shouldBypassFetch(props, [name, config]) ||
+      (getModelFromCache(config) && !getModelFromCache(config).lazy)) ?
+      defaultState :
+      (!hasAllDependencies(props, [, config]) ? LoadingStates.PENDING : LoadingStates.LOADING)
   }), {});
 }
 
@@ -683,10 +684,10 @@ function modelAggregator(resources) {
 
 /**
  * Separates out resources between those that are loading and those that have loaded. The latter
- * won't need to get passed to fetchResources, but the former will. Make sure that prefetched
- * resources get added to those that are loading so that the request gets made. Since prefetched
- * models don't factor into loading states, there's no concern that they get passed to
- * fetchResources even if they have been cached.
+ * won't need to get passed to fetchResources, but the former will. Make sure that prefetched,
+ * refetched, and lazy resources get added to those that are loading so that the request gets made.
+ * Since prefetched models don't factor into loading states, there's no concern that they get passed
+ * to fetchResources even if they have been cached.
  *
  * @param {array[]} resourcesToUpdate - resource configs to partition
  * @param {object} loadingStates - contains upcoming loading states for each resource
@@ -695,7 +696,8 @@ function modelAggregator(resources) {
  */
 function partitionResources(resourcesToUpdate, loadingStates) {
   return resourcesToUpdate.reduce((memo, [name, config]) =>
-    config.refetch || config.prefetch || !hasLoaded(loadingStates[getResourceState(name)]) ?
+    config.refetch || config.prefetch || !hasLoaded(loadingStates[getResourceState(name)]) ||
+      getModelFromCache(config)?.lazy ?
       [memo[0], memo[1].concat([[name, config]])] :
       [memo[0].concat([[name, config]]), memo[1]],
   [[], []]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/use-resources.test.jsx
+++ b/test/use-resources.test.jsx
@@ -1187,6 +1187,30 @@ describe('useResources', () => {
     await waitsFor(() => dataChild.props.hasLoaded);
   });
 
+  it('fetches lazily-cached resources', async() => {
+    var decisionsCollection = new Collection(),
+        userModel = new Model();
+
+    decisionsCollection.lazy = true;
+    // lazy
+    ModelCache.put('decisions', decisionsCollection);
+    // not lazy
+    ModelCache.put('userfraudLevel=high_userId=noah', userModel);
+
+    dataChild = findDataChild(renderUseResources());
+
+    expect(dataChild.props.decisionsLoadingState).toEqual(LoadingStates.LOADING);
+    expect(dataChild.props.userLoadingState).toBe(LoadingStates.LOADED);
+
+    await waitsFor(() => dataChild.props.hasLoaded);
+
+    // users not called, but decisions called
+    expect(requestSpy.mock.calls.map(([name]) => name)).toEqual([
+      ResourceKeys.DECISIONS,
+      ResourceKeys.ANALYSTS
+    ]);
+  });
+
   it('isOrWillBeLoading is true for two cycles that props change and loading starts', async() => {
     dataChild = findDataChild(renderUseResources());
 

--- a/test/with-resources.test.jsx
+++ b/test/with-resources.test.jsx
@@ -1236,6 +1236,30 @@ describe('withResources', () => {
     await waitsFor(() => dataChild.props.hasLoaded);
   });
 
+  it('fetches lazily-cached resources', async() => {
+    var decisionsCollection = new Collection(),
+        userModel = new Model();
+
+    decisionsCollection.lazy = true;
+    // lazy
+    ModelCache.put('decisions', decisionsCollection);
+    // not lazy
+    ModelCache.put('userfraudLevel=high_userId=noah', userModel);
+
+    dataChild = findDataChild(renderWithResources());
+
+    expect(dataChild.props.decisionsLoadingState).toEqual(LoadingStates.LOADING);
+    expect(dataChild.props.userLoadingState).toBe(LoadingStates.LOADED);
+
+    await waitsFor(() => dataChild.props.hasLoaded);
+
+    // users not called, but decisions called
+    expect(requestSpy.mock.calls.map(([name]) => name)).toEqual([
+      ResourceKeys.DECISIONS,
+      ResourceKeys.ANALYSTS
+    ]);
+  });
+
   it('isOrWillBeLoading is true for two cycles that props change and loading starts', async() => {
     dataChild = findDataChild(renderWithResources());
 


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
- #116 added a lazy consideration for the requesting, but the hook was still considering it a loaded resource so if it was cached lazily _first_, then it was never actually passed to the request module.

## Description of Proposed Changes:  
  -  Just like the `refetch` option, where we want to consider it not loaded even if it has already loaded, consider a lazy model not loaded no matter what

