### PR TITLE
remove lazy when fetch completes

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -69,11 +69,14 @@ export default (key, Model, options={}) => {
         if (options.fetch && !options.lazy) {
           addToLoadingCache = true;
 
-          delete model.lazy;
-
           model.fetch({params: options.params}).then(
             ([newModel, response]) => {
               delete loadingCache[key];
+              // waiting to delete lazy property until after fetch completes ensures multiple
+              // components that call non-lazy version of the resource all get put into a
+              // loading state
+              delete model.lazy;
+
               ModelCache.put(key, newModel, options.component);
               resolve([newModel, response?.status]);
             },
@@ -83,7 +86,7 @@ export default (key, Model, options={}) => {
             }
           );
         } else {
-          // lazy means resolove but don't fetch yet; it will get updates from other components
+          // lazy means resolve but don't fetch yet; it will get updates from other components
           // we only want to do this if a model is not yet in the cache
           options.lazy && !ModelCache.get(key) ? model.lazy = true : null;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -306,12 +306,17 @@ describe('Request', () => {
       });
 
       it('fetches when another component requests the same model without lazy option', async() => {
-        var [model] = await request('lazy', Model, {component, lazy: true});
+        var [model] = await request('lazy', Model, {component, lazy: true}),
+            requestPromise;
 
         expect(model.lazy).toBe(true);
         expect(Model.prototype.fetch).not.toHaveBeenCalled();
 
-        [model] = await request('lazy', Model, {component});
+        requestPromise = request('lazy', Model, {component});
+
+        expect(model.lazy).toBeDefined();
+        await requestPromise;
+
         expect(model.lazy).not.toBeDefined();
         expect(Model.prototype.fetch).toHaveBeenCalled();
 


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
If we remove the `lazy` property before the first-non-lazy fetch completes, then any other component that wants to non-lazy fetch the resource will not get put in a loading state.

## Description of Proposed Changes:  
  -  waits until the fetch completes to remove the `lazy` flag on the model

