### PR TITLE
check lazy changes when determining which resources to update

### DIFF
--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -101,17 +101,21 @@ export const useResources = (getResources, props) => {
       listenedModelsRef = useRef([]),
 
       forceUpdate = useForceUpdate(),
-      getPrevCacheKey = (rsrc) => findCacheKey(rsrc, getResources, prevPropsRef.current),
+
       // note that this only tells when cache keys have changed. if a resource has already been
       // cached, this will still return its resource when the component mounts. that's why we
       // partition these out later into loaded and not loaded resources
       getResourcesToUpdate = (rsrcs) => rsrcs.filter(hasAllDependencies.bind(null, props))
           .filter(not(shouldBypassFetch.bind(null, props)))
           .filter(([name, config]) => {
-            var previousCacheKey = prevPropsRef.current && getPrevCacheKey([name, config]);
+            var prevConfig = findConfig([name, config], getResources, prevPropsRef.current || {}),
+                previousCacheKey = prevPropsRef.current && getCacheKey(prevConfig);
 
             return (!previousCacheKey || previousCacheKey !== getCacheKey(config) ||
-              !hasAllDependencies(prevPropsRef.current, [, config]) || config.refetch);
+              !hasAllDependencies(prevPropsRef.current, [, config]) || config.refetch ||
+              // make sure if we were lazy and are no longer lazy (from the same component) that we
+              // get included in the list to get updated
+              (prevConfig.lazy && !config.lazy));
           });
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/with-resources.test.jsx
+++ b/test/with-resources.test.jsx
@@ -54,6 +54,7 @@ class DefaultTestChildren extends React.Component {
   },
   [DECISIONS]: {
     ...(props.includeDeleted ? {params: {include_deleted: true}} : {}),
+    lazy: props.lazy,
     measure
   },
   [NOTES]: {data: {pretend: true}, noncritical: true, dependsOn: ['noah']},
@@ -1258,6 +1259,21 @@ describe('withResources', () => {
       ResourceKeys.DECISIONS,
       ResourceKeys.ANALYSTS
     ]);
+
+    requestSpy.mockClear();
+    ModelCache.remove('decisions');
+
+    // now let's test the case where a single component changes its lazy status
+    dataChild = findDataChild(renderWithResources({lazy: true}));
+
+    expect(dataChild.props.decisionsLoadingState).toEqual(LoadingStates.LOADED);
+    expect(dataChild.props.hasLoaded).toBe(true);
+    expect(requestSpy.mock.calls.map(([name]) => name)).toEqual([]);
+
+    dataChild = findDataChild(renderWithResources({lazy: false}));
+
+    await waitsFor(() => dataChild.props.hasLoaded);
+    expect(requestSpy.mock.calls.map(([name]) => name)).toEqual([ResourceKeys.DECISIONS]);
   });
 
   it('isOrWillBeLoading is true for two cycles that props change and loading starts', async() => {


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

#119 only added a non-lazy request to the resources-to-update list if it came from a separate component. This adds it if it's coming from the same component where a resource's `lazy` value changes.

## Description

- checks resource config object `lazy` property when determining whether a resource should update.
