### PR TITLE
do not call getResources with empty props

### DIFF
--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -108,14 +108,15 @@ export const useResources = (getResources, props) => {
       getResourcesToUpdate = (rsrcs) => rsrcs.filter(hasAllDependencies.bind(null, props))
           .filter(not(shouldBypassFetch.bind(null, props)))
           .filter(([name, config]) => {
-            var prevConfig = findConfig([name, config], getResources, prevPropsRef.current || {}),
-                previousCacheKey = prevPropsRef.current && getCacheKey(prevConfig);
+            var prevConfig = prevPropsRef.current &&
+                  findConfig([name, config], getResources, prevPropsRef.current),
+                previousCacheKey = prevConfig && getCacheKey(prevConfig);
 
             return (!previousCacheKey || previousCacheKey !== getCacheKey(config) ||
               !hasAllDependencies(prevPropsRef.current, [, config]) || config.refetch ||
               // make sure if we were lazy and are no longer lazy (from the same component) that we
               // get included in the list to get updated
-              (prevConfig.lazy && !config.lazy));
+              (prevConfig?.lazy && !config.lazy));
           });
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

A regression introduced by #121 where `getResources` was getting called with previous props, which are empty when first mounting.

## Description of Proposed Changes:  
  - Adds checks to ensure previous props exist before calling `getResources` with them
  
