### PR TITLE
reregister resources to updated that already cached

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -93,6 +93,10 @@ export default (key, Model, options={}) => {
           ModelCache.put(key, model, options.component);
           resolve([model]);
         }
+      // this block normally will not get invoked because previous-cached resources will bypass
+      // the request module to avoid the async Promise tick. this will still get called for some
+      // unconventional resource loading such as prefetch requests that are cached, both from the
+      // prefetch module and from the `prefetches` resource config property
       } else {
         // this will cancel any in-flight timeouts and add the component
         // to the list of components using the resource

--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -163,6 +163,13 @@ export const useResources = (getResources, props) => {
       setModels(modelAggregator(pendingResources.concat(loadedResources).filter(withoutPrefetch)));
     }
 
+    // because we don't go through the request module for normal-flow resources that are cached,
+    // we need to re-register this component with the resource. this will also clear any timeouts
+    // for removing the resource.
+    loadedResources.map(
+      ([, config]) => ModelCache.register(getCacheKey(config), componentRef.current)
+    );
+
     // NOTE: changing this to resourcesToFetch causes some inexplicable bugs around cached resources
     // and a UI that wouldn't update. so this is kept as resourcesToUpdate and fetchResources is
     // given resourcesToFetch. Because we are still only fetching resourcesToFetch and because any

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "1.0.5",
+      "version": "1.0.7",
       "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/use-resources.test.jsx
+++ b/test/use-resources.test.jsx
@@ -559,21 +559,29 @@ describe('useResources', () => {
     });
 
     it('for a cached resource', async() => {
+      var userModel = new UserModel({}, {userId: 'zorah'});
+
+      ModelCache.put('useruserId=zorah', userModel);
+
       // this test is just to ensure that, when a cached resource is requested
       // on an update, which means it resolves its promise immediately, that the
       // loading state is still set (because the cache key should equal the cache
       // key check in the resolve handler).
+      jest.spyOn(ModelCache, 'register');
       dataChild = findDataChild(renderUseResources({shouldError: true}));
 
       await waitsFor(() => dataChild.props.hasErrored);
       expect(dataChild.props.userLoadingState).toEqual(LoadingStates.ERROR);
 
+      ModelCache.register.mockClear();
       // rerender with a new user, but the user that's 'already cached'
       dataChild = findDataChild(renderUseResources({userId: 'zorah', fraudLevel: null}));
 
       // now assert that we turn back to a loaded state from the cached resource
       await waitsFor(() => dataChild.props.hasLoaded);
-      expect(dataChild.props.userModel.userId).toEqual('zorah');
+      expect(ModelCache.register).toHaveBeenCalledWith('useruserId=zorah', {});
+      expect(dataChild.props.userModel).toEqual(userModel);
+      ModelCache.register.mockRestore();
     });
   });
 

--- a/test/with-resources.test.jsx
+++ b/test/with-resources.test.jsx
@@ -585,21 +585,29 @@ describe('withResources', () => {
     });
 
     it('for a cached resource', async() => {
+      var userModel = new UserModel({}, {userId: 'zorah'});
+
+      ModelCache.put('useruserId=zorah', userModel);
+
       // this test is just to ensure that, when a cached resource is requested
       // on an update, which means it resolves its promise immediately, that the
       // loading state is still set (because the cache key should equal the cache
       // key check in the resolve handler).
+      jest.spyOn(ModelCache, 'register');
       dataChild = findDataChild(renderWithResources({shouldError: true}));
 
       await waitsFor(() => dataChild.props.hasErrored);
       expect(dataChild.props.userLoadingState).toEqual(LoadingStates.ERROR);
 
+      ModelCache.register.mockClear();
       // rerender with a new user, but the user that's 'already cached'
       dataChild = findDataChild(renderWithResources({userId: 'zorah', fraudLevel: null}));
 
       // now assert that we turn back to a loaded state from the cached resource
       await waitsFor(() => dataChild.props.hasLoaded);
-      expect(dataChild.props.userModel.userId).toEqual('zorah');
+      expect(ModelCache.register).toHaveBeenCalledWith('useruserId=zorah', {});
+      expect(dataChild.props.userModel).toEqual(userModel);
+      ModelCache.register.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

A bug where already-cached resources were not getting re-registered in the ModelCache. The subtle bug is that if a resource is scheduled for removal and then, before it gets removed, a new component that uses it is mounted, the resource still gets removed. This stems from the change where we stopped running cached resources through the request module and instead set them immediately as state. As a consequence, [this block](https://github.com/noahgrant/resourcerer/blob/4b257fb93d2d2cb69976a539d28053bbc0d0986f/lib/request.js#L97-L103) was no longer getting called for normal-flow resources.

## Description of Proposed Changes:  
  -  Runs each loaded resource through `ModelCache.register` in the effect before requests are made

