### PR TITLE
pass urlOptions from collection to model

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -471,7 +471,7 @@ export default class Collection {
       return attrs;
     }
 
-    return new this.Model(attrs, {...options, collection: this});
+    return new this.Model(attrs, {...this.urlOptions, ...options, collection: this});
   }
 
   /**

--- a/lib/model.js
+++ b/lib/model.js
@@ -3,6 +3,16 @@ import {isDeepEqual, result, uniqueId, urlError} from './utils';
 import Events from './events';
 import sync from './sync';
 
+const RESERVED_OPTION_KEYS = [
+  'Model',
+  'comparator',
+  'parse',
+  'collection',
+  'silent',
+  'method',
+  'unset'
+];
+
 /**
  * The Model class should be extended for any resource that is singular, as in not a list of items.
  * It is the core class used to represent server data in the client application (Collections are
@@ -26,8 +36,6 @@ export default class Model {
    *   * ...any other options that .set() takes
    */
   constructor(attributes={}, options={}) {
-    const RESERVED_OPTION_KEYS = ['parse', 'collection', 'silent', 'unset'];
-
     this.cid = uniqueId('c');
     this.attributes = {};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.10.5",
@@ -26,8 +26,8 @@
         "whatwg-fetch": "^3.6.2"
       },
       "peerDependencies": {
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react": "^16.14.0 || ^17.0.0",
+        "react-dom": "^16.14.0 || ^17.0.0"
       }
     },
     "node_modules/@babel/cli": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/collection.test.js
+++ b/test/collection.test.js
@@ -50,6 +50,19 @@ describe('Collection', () => {
     expect(collection.toJSON()).toEqual([]);
   });
 
+  it('urlOptions get passed down to models', async() => {
+    collection = new Collection([{id: '1'}], {one: 1, two: 2, comparator: 'foo', parse: true});
+
+    expect(collection.get('1').urlOptions).toEqual({one: 1, two: 2});
+
+    collection.add({id: '2'});
+    expect(collection.get('2').urlOptions).toEqual({one: 1, two: 2});
+
+    sync.default.mockResolvedValue([[{id: '3'}], {}]);
+    await collection.fetch();
+    expect(collection.get('3').urlOptions).toEqual({one: 1, two: 2});
+  });
+
   it('adds any models passed to its models list', () => {
     var model1 = new Model,
         model2 = new Model;


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

Fixes an issue where urlOptions are not passed down to the Model in all cases. They are when a Collection is instantiated with the models, but not when the models are instantiated later, as in after a fetch. In that case, the urlOptions set on the collection are not present in the fetch `options` parameter.

## Description of Proposed Changes:  
  -  Merges `this.urlOptions` with `options` parameter when instantiating all models
