### PR TITLE
set only returned model as state

### DIFF
--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -204,9 +204,7 @@ export const useResources = (getResources, props) => {
           // https://stackoverflow.com/questions/48563650/
           // does-react-keep-the-order-for-state-updates/48610973#48610973
           ReactDOM.unstable_batchedUpdates(() => {
-            if (resources.filter(withoutPrefetch).length) {
-              setModels(modelAggregator(resources.filter(withoutPrefetch)));
-            }
+            setModels(modelAggregator([[name, config]]));
 
             loaderDispatch({
               type: LoadingStates.LOADED,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

An issue where stale resource configs from a previous render cycle's closure will get set as model state, overriding newer resource configs. This can happen, for example, when one resource in an executor function takes much longer than the others.

## Description of Proposed Changes:  
  -  Instead of setting all resources from a resource config as state when a single resource returns, only set the resource that returned.
  
