### PR TITLE
set empty models as state when erroring

### DIFF
--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -212,10 +212,17 @@ export const useResources = (getResources, props) => {
             });
           });
         },
-        onRequestFailure: (status, [name, config]) => loaderDispatch({
-          type: LoadingStates.ERROR,
-          payload: {name, config, status}
-        })
+        onRequestFailure: (status, [name, config]) => {
+          // request failed, which means this model should not be in the cache. but we still want to
+          // set our model state so that when we go back into a loading state, the empty model
+          // is present instead of any previously-loaded model
+          setModels(modelAggregator([[name, config]]));
+
+          loaderDispatch({
+            type: LoadingStates.ERROR,
+            payload: {name, config, status}
+          });
+        }
       }).then(() => {
         if (isMountedRef.current) {
           // only get those from the cache. models in state might can empty models, but even so i

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/use-resources.test.jsx
+++ b/test/use-resources.test.jsx
@@ -600,18 +600,24 @@ describe('useResources', () => {
       expect(dataChild.props.notesModel.get('pretend')).toBe(true);
       expect(dataChild.props.notesModel instanceof NotesModel).toBe(true);
 
-      await unmountAndClearModelCache();
-
-      // the models are removed from the cache after erroring
       shouldResourcesError = true;
-      dataChild = findDataChild(renderUseResources());
+      dataChild = findDataChild(renderUseResources({userId: 'zorah'}));
 
       await waitsFor(() => dataChild.props.hasErrored);
 
-      expect(dataChild.props.decisionsCollection.isEmptyModel).toBe(true);
-      expect(dataChild.props.decisionsCollection instanceof DecisionsCollection).toBe(true);
+      expect(dataChild.props.userModel.isEmptyModel).toBe(true);
+      expect(dataChild.props.userModel instanceof UserModel).toBe(true);
+
+      shouldResourcesError = false;
+      // now request a different resource and assert that our model is still empty (because it
+      // is set as state)
+      dataChild = findDataChild(renderUseResources({userId: 'lopatron'}));
 
       expect(dataChild.props.userModel.isEmptyModel).toBe(true);
+      expect(dataChild.props.userModel instanceof UserModel).toBe(true);
+
+      await waitsFor(() => dataChild.props.hasLoaded);
+      expect(dataChild.props.userModel.isEmptyModel).not.toBeDefined();
       expect(dataChild.props.userModel instanceof UserModel).toBe(true);
     });
 

--- a/test/with-resources.test.jsx
+++ b/test/with-resources.test.jsx
@@ -626,18 +626,24 @@ describe('withResources', () => {
       expect(dataChild.props.notesModel.get('pretend')).toBe(true);
       expect(dataChild.props.notesModel instanceof NotesModel).toBe(true);
 
-      await unmountAndClearModelCache();
-
-      // the models are removed from the cache after erroring
       shouldResourcesError = true;
-      dataChild = findDataChild(renderWithResources());
+      dataChild = findDataChild(renderWithResources({userId: 'zorah'}));
 
       await waitsFor(() => dataChild.props.hasErrored);
 
-      expect(dataChild.props.decisionsCollection.isEmptyModel).toBe(true);
-      expect(dataChild.props.decisionsCollection instanceof DecisionsCollection).toBe(true);
+      expect(dataChild.props.userModel.isEmptyModel).toBe(true);
+      expect(dataChild.props.userModel instanceof UserModel).toBe(true);
+
+      shouldResourcesError = false;
+      // now request a different resource and assert that our model is still empty (because it
+      // is set as state)
+      dataChild = findDataChild(renderWithResources({userId: 'lopatron'}));
 
       expect(dataChild.props.userModel.isEmptyModel).toBe(true);
+      expect(dataChild.props.userModel instanceof UserModel).toBe(true);
+
+      await waitsFor(() => dataChild.props.hasLoaded);
+      expect(dataChild.props.userModel.isEmptyModel).not.toBeDefined();
       expect(dataChild.props.userModel instanceof UserModel).toBe(true);
     });
 


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

Currently when a resource errors, we don't set any model as state. This is fine if a resource errors for the first request of a component, because it will just stay the initial empty model. However, if an initial request succeeds for a component, and then a subsequent request errors, the model will still be the stale model from the success request. This PR re-sets the empty model as state when a request errors.

## Description of Proposed Changes:  
  -  On error, set model state. Because nothing will be in the model cache (since we don't add to the cache on error), the empty model will get set

