### PR TITLE
Allow lazy lazy

### DIFF
--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -115,8 +115,8 @@ export const useResources = (getResources, props) => {
             return (!previousCacheKey || previousCacheKey !== getCacheKey(config) ||
               !hasAllDependencies(prevPropsRef.current, [, config]) || config.refetch ||
               // make sure if we were lazy and are no longer lazy (from the same component) that we
-              // get included in the list to get updated
-              (prevConfig?.lazy && !config.lazy));
+              // get included in the list to get updated (and vice versa)
+              (prevConfig?.lazy !== config.lazy));
           });
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/use-resources.test.jsx
+++ b/test/use-resources.test.jsx
@@ -40,7 +40,7 @@ const getResources = ({
     params: {shouldError: props.analystsError}
   },
   [DECISIONS]: {
-    ...(props.includeDeleted ? {params: {include_deleted: true}} : {}),
+    ...props.includeDeleted ? {params: {include_deleted: true}} : {},
     lazy: props.lazy,
     measure
   },
@@ -1226,6 +1226,7 @@ describe('useResources', () => {
     ]);
 
     requestSpy.mockClear();
+    Collection.prototype.fetch.mockClear();
     ModelCache.remove('decisions');
 
     // now let's test the case where a single component changes its lazy status
@@ -1233,12 +1234,13 @@ describe('useResources', () => {
 
     expect(dataChild.props.decisionsLoadingState).toEqual(LoadingStates.LOADED);
     expect(dataChild.props.hasLoaded).toBe(true);
-    expect(requestSpy.mock.calls.map(([name]) => name)).toEqual([]);
+    expect(Collection.prototype.fetch).not.toHaveBeenCalled();
 
     dataChild = findDataChild(renderUseResources({lazy: false}));
 
     await waitsFor(() => dataChild.props.hasLoaded);
-    expect(requestSpy.mock.calls.map(([name]) => name)).toEqual([ResourceKeys.DECISIONS]);
+    expect(Collection.prototype.fetch).toHaveBeenCalledTimes(1);
+    expect(Collection.prototype.fetch.mock.instances[0] instanceof DecisionsCollection).toBe(true);
   });
 
   it('isOrWillBeLoading is true for two cycles that props change and loading starts', async() => {

--- a/test/with-resources.test.jsx
+++ b/test/with-resources.test.jsx
@@ -1275,6 +1275,7 @@ describe('withResources', () => {
     ]);
 
     requestSpy.mockClear();
+    Collection.prototype.fetch.mockClear();
     ModelCache.remove('decisions');
 
     // now let's test the case where a single component changes its lazy status
@@ -1282,12 +1283,13 @@ describe('withResources', () => {
 
     expect(dataChild.props.decisionsLoadingState).toEqual(LoadingStates.LOADED);
     expect(dataChild.props.hasLoaded).toBe(true);
-    expect(requestSpy.mock.calls.map(([name]) => name)).toEqual([]);
+    expect(Collection.prototype.fetch).not.toHaveBeenCalled();
 
     dataChild = findDataChild(renderWithResources({lazy: false}));
 
     await waitsFor(() => dataChild.props.hasLoaded);
-    expect(requestSpy.mock.calls.map(([name]) => name)).toEqual([ResourceKeys.DECISIONS]);
+    expect(Collection.prototype.fetch).toHaveBeenCalledTimes(1);
+    expect(Collection.prototype.fetch.mock.instances[0] instanceof DecisionsCollection).toBe(true);
   });
 
   it('isOrWillBeLoading is true for two cycles that props change and loading starts', async() => {


### PR DESCRIPTION
## Description of Proposed Changes:  
  -  Previously, only models that went from lazy to not lazy were supported (initially not fetched, then fetched)
  -  Here we support models that are initially not lazy and then are moved to lazy. One use case is for resources that don't exist and 404 from an API. In that case, we might still want to edit the returned model directly and listen on changes, but when a resource errors the empty model is returned (not listened on, and frozen, anyway).
  - Tests regarding this were improved
  - Lazy behavior is not publicly documented (so still 'officially' in beta) 
