### PR TITLE
Allow model specific timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,7 +755,7 @@ The hook and HOC largely operate interchangeably, but do note a couple critical 
 
 `resourcerer` handles resource storage and caching, so that when multiple components request the same resource with the same parameters or the same body, they receive the same model in response. If multiple components request a resource still in-flight, only a single request is made, and each component awaits the return of the same resource. Fetched resources are stored in the `ModelCache`. Under most circumstances, you won’t need to interact with directly; but it’s still worth knowing a little bit about what it does.
 
-The `ModelCache` is a simple module that contains a couple of Maps&mdash;one that is the actual cache `{cacheKey<string>: model<Model|Collection>}`, and one that is a component manifest, keeping track of all component instances that are using a given resource (unique by cache key). When a component unmounts, `resourcerer` will unregister the component instance from the component manifest; if a resource no longer has any component instances attached, it gets scheduled for cache removal. The timeout period for cache removal is two minutes by default (but can be changed, see [Configuring resourcerer](#configuring-resourcerer)), to allow navigating back and forth between pages without requiring a refetch of all resources. After the timeout, if no other new component instances have requested the resource, it’s removed from the `ModelCache`. Any further requests for that resource then go back through the network.
+The `ModelCache` is a simple module that contains a couple of Maps&mdash;one that is the actual cache `{cacheKey<string>: model<Model|Collection>}`, and one that is a component manifest, keeping track of all component instances that are using a given resource (unique by cache key). When a component unmounts, `resourcerer` will unregister the component instance from the component manifest; if a resource no longer has any component instances attached, it gets scheduled for cache removal. The timeout period for cache removal is two minutes by default (but can be changed, see [Configuring resourcerer](#configuring-resourcerer), or [overridden on a model-class basis](/docs/model.md#static-cachetimeout)), to allow navigating back and forth between pages without requiring a refetch of all resources. After the timeout, if no other new component instances have requested the resource, it’s removed from the `ModelCache`. Any further requests for that resource then go back through the network.
 
 Again, it’s unlikely that you’ll use `ModelCache` directly while using `resourcerer`, but it’s helpful to know a bit about what’s going on behind-the-scenes.
 
@@ -900,7 +900,7 @@ ResourcesConfig.set(configObj);
 
 `ResourcesConfig.set` accepts an object with any of the following properties:
 
-* `cacheGracePeriod` (number in ms): the length of time a resource will be kept in the cache after being scheduled for removal (see the [caching section](#caching-resources-with-modelcache) for more). **Default:** 120000 (2 minutes).
+* `cacheGracePeriod` (number in ms): the length of time a resource will be kept in the cache after being scheduled for removal (see the [caching section](#caching-resources-with-modelcache) for more). **Default:** 120000 (2 minutes). Note that each model class can provide its own timeout override.
 
 * `errorBoundaryChild` (JSX/React.Element): the element or component that should be rendered in the ErrorBoundary included in every `withResources` wrapping. By default, a caught error renders this child:
 

--- a/docs/collection.md
+++ b/docs/collection.md
@@ -41,6 +41,11 @@ Set this property if you want a collection's models to be an instance of a class
 
 This property tells resourcerer how to determine whether to make a new request or to take a collection out of the cache. It is an array of strings or functions from which its cache key is calculated. See the [cacheKey](https://github.com/noahgrant/resourcerer#caching-resources-with-modelcache) section for more info.
 
+### `static` cacheTimeout
+`number`
+
+The number of milliseconds to keep all collections of this class in the cache after all client components stop referencing it. Note that this is on a collection _class_ basis and not an _instance_ basis because the latter can introduce race conditions into your application.
+
 ### `static` measure
 `boolean|function`
 

--- a/docs/model.md
+++ b/docs/model.md
@@ -45,6 +45,11 @@ that you might find useful in rendering your data-hydrated components.
 
 This property tells resourcerer how to determine whether to make a new request or to take a model out of the cache. It is an array of strings or functions from which its cache key is calculated. See the [cacheKey](https://github.com/noahgrant/resourcerer#caching-resources-with-modelcache) section for more info.
 
+### `static` cacheTimeout
+`number`
+
+The number of milliseconds to keep all models of this class in the cache after all client components stop referencing it. Note that this is on a model _class_ basis and not an _instance_ basis because the latter can introduce race conditions into your application.
+
 ### `static` idAttribute
 `string`. Default: `'id'`.  
 

--- a/lib/model-cache.js
+++ b/lib/model-cache.js
@@ -113,9 +113,10 @@ export default {
  * @param {string} cacheKey - The cache key of the model to be removed.
  */
 function scheduleForRemoval(cacheKey) {
-  timeouts[cacheKey] = window.setTimeout(() => {
-    clearModel(cacheKey);
-  }, ResourcesConfig.cacheGracePeriod);
+  var timeout = modelCache.get(cacheKey)?.constructor.cacheTimeout ||
+    ResourcesConfig.cacheGracePeriod;
+
+  timeouts[cacheKey] = window.setTimeout(() => clearModel(cacheKey), timeout);
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [

--- a/test/model-cache.test.js
+++ b/test/model-cache.test.js
@@ -1,3 +1,5 @@
+import Collection from '../lib/collection';
+import Model from '../lib/model';
 import ModelCache from '../lib/model-cache';
 
 const CACHE_WAIT = 150000,
@@ -49,6 +51,31 @@ describe('ModelCache', () => {
         // model should be removed after CACHE_WAIT time
         expect(ModelCache.get(PUT_KEY)).toBeDefined();
         jest.advanceTimersByTime(CACHE_WAIT);
+        expect(ModelCache.get(PUT_KEY)).not.toBeDefined();
+      });
+
+      it('uses a model-specific timeout if available', () => {
+        class TimeoutModel extends Model {
+          static cacheTimeout = 3000;
+        }
+
+        class TimeoutCollection extends Collection {
+          static cacheTimeout = CACHE_WAIT + 2000;
+        }
+
+        jest.advanceTimersByTime(CACHE_WAIT);
+        expect(ModelCache.get(PUT_KEY)).not.toBeDefined();
+
+        ModelCache.put(PUT_KEY, new TimeoutModel());
+        jest.advanceTimersByTime(2000);
+        expect(ModelCache.get(PUT_KEY)).toBeDefined();
+        jest.advanceTimersByTime(2000);
+        expect(ModelCache.get(PUT_KEY)).not.toBeDefined();
+
+        ModelCache.put(PUT_KEY, new TimeoutCollection());
+        jest.advanceTimersByTime(CACHE_WAIT);
+        expect(ModelCache.get(PUT_KEY)).toBeDefined();
+        jest.advanceTimersByTime(2000);
         expect(ModelCache.get(PUT_KEY)).not.toBeDefined();
       });
     });


### PR DESCRIPTION
## Description of Proposed Changes:  
  -  Allows models to add a static `cacheTimeout` property on the constructor to override the default timeout used for the rest of the app.

