### PR TITLE
type: module and no jsx

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -208,19 +208,6 @@
     "wrap-iife": [2, "inside"],
     "yoda": [2, "never", {"exceptRange": true}]
   },
-  "globals": {
-    "babel": false,
-    "Bloodhound": false,
-    "CodeMirror": false,
-    "confirm": false,
-    "fetch": false,
-    "FontFaceObserver": false,
-    "mapboxgl": false,
-    "mixpanel": false,
-    "mostRecentAjaxRequest": false,
-    "mpPageName": false,
-    "olark": false
-  },
   "plugins": [
     "jest",
     "react",

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-export {default as Collection} from './lib/collection';
-export {default as Model} from './lib/model';
-export {default as sync, ajax} from './lib/sync';
+export {default as Collection} from './lib/collection.js';
+export {default as Model} from './lib/model.js';
+export {default as sync, ajax} from './lib/sync.js';
 export {default as prefetch} from './lib/prefetch.js';
 export {default as request} from './lib/request.js';
 export {default as ModelCache} from './lib/model-cache.js';

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,8 +1,8 @@
-import {isDeepEqual, sortBy} from './utils';
+import {isDeepEqual, sortBy} from './utils.js';
 
-import Events from './events';
-import Model from './model';
-import sync from './sync';
+import Events from './events.js';
+import Model from './model.js';
+import sync from './sync.js';
 
 /**
  * A Collection instance represents a list of items in a RESTful sense. Each item returned at the

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
-import {camelize, noOp} from './utils';
+import {camelize, noOp} from './utils.js';
 import React from 'react';
-import {setRequestPrefilter} from './sync';
+import {setRequestPrefilter} from './sync.js';
 
 /**
  * This module contains all the required setup for implementing withResources

--- a/lib/error-boundary.js
+++ b/lib/error-boundary.js
@@ -1,6 +1,6 @@
-import {omit} from './utils';
+import {omit} from './utils.js';
 import React from 'react';
-import {ResourcesConfig} from './config';
+import {ResourcesConfig} from './config.js';
 
 /**
  * As of React 16, Error Boundaries (components with a componentDidCatch method)

--- a/lib/model-cache.js
+++ b/lib/model-cache.js
@@ -1,4 +1,4 @@
-import {ResourcesConfig} from './config';
+import {ResourcesConfig} from './config.js';
 
 // this is where all of our cached resources are stored
 const modelCache = new Map();

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,7 +1,7 @@
-import {isDeepEqual, result, uniqueId, urlError} from './utils';
+import {isDeepEqual, result, uniqueId, urlError} from './utils.js';
 
-import Events from './events';
-import sync from './sync';
+import Events from './events.js';
+import sync from './sync.js';
 
 const RESERVED_OPTION_KEYS = [
   'Model',

--- a/lib/prefetch.js
+++ b/lib/prefetch.js
@@ -1,8 +1,8 @@
-import {ModelMap, ResourceKeys} from './config';
-import {noOp, once} from './utils';
+import {ModelMap, ResourceKeys} from './config.js';
+import {noOp, once} from './utils.js';
 
-import {getCacheKey} from './resourcerer';
-import request from './request';
+import {getCacheKey} from './resourcerer.js';
+import request from './request.js';
 
 // prevents api request bursts based on quick swipes
 const PREFETCH_TIMEOUT = 50;

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,5 +1,5 @@
-import Collection from './collection';
-import ModelCache from './model-cache';
+import Collection from './collection.js';
+import ModelCache from './model-cache.js';
 
 const loadingCache = {};
 

--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -1,16 +1,16 @@
-import {hasErrored, hasLoaded, isLoading} from './utils';
-import {ModelMap, ResourceKeys, ResourcesConfig, UnfetchedResources} from './config';
+import {hasErrored, hasLoaded, isLoading} from './utils.js';
+import {ModelMap, ResourceKeys, ResourcesConfig, UnfetchedResources} from './config.js';
 /* eslint-disable no-unused-vars */
 import React, {useEffect, useReducer, useRef, useState} from 'react';
 /* eslint-enable no-unused-vars */
 
-import Collection from './collection';
-import ErrorBoundary from './error-boundary';
-import {LoadingStates} from './constants';
-import Model from './model';
-import ModelCache from './model-cache';
+import Collection from './collection.js';
+import ErrorBoundary from './error-boundary.js';
+import {LoadingStates} from './constants.js';
+import Model from './model.js';
+import ModelCache from './model-cache.js';
 import ReactDOM from 'react-dom';
-import request from './request';
+import request from './request.js';
 
 const SPREAD_PROVIDES_CHAR = '_';
 
@@ -340,9 +340,12 @@ export const withResources = (getResources) => (Component) =>
     var resources = useResources(getResources, props);
 
     return (
-      <ErrorBoundary>
-        <Component {...props} {...resources} />
-      </ErrorBoundary>
+      React.createElement(ErrorBoundary, {
+        children: React.createElement(Component, {
+          ...props,
+          ...resources
+        })
+      })
     );
   };
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -1,6 +1,6 @@
-import {result, urlError} from './utils';
+import {result, urlError} from './utils.js';
 
-import {ResourcesConfig} from './config';
+import {ResourcesConfig} from './config.js';
 
 const MIME_TYPE_JSON = 'application/json';
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-import {LoadingStates} from './constants';
+import {LoadingStates} from './constants.js';
 
 /**
  * Whether or not any loading state has errored. If a state is passed in,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": [
@@ -16,6 +16,7 @@
     "docs/*.md"
   ],
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "checks": "npm test && npm run lint",
     "lint": "eslint lib/*.js* test/*.js*",
@@ -36,7 +37,7 @@
     ],
     "testEnvironment": "jsdom"
   },
-  "module": "index.js",
+  "exports": "index.js",
   "devDependencies": {
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.10.5",


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

A few things to make it easier to bundle out of the box:
- Removes the small amount of jsx to just use .js files
- use `type: "module"` in package.json so that `import`/`export` are recognized
- make sure all imports have `.js` suffixes 
