### PR TITLE
ensure provided props get added when model is cached

### DIFF
--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -166,9 +166,13 @@ export const useResources = (getResources, props) => {
     // because we don't go through the request module for normal-flow resources that are cached,
     // we need to re-register this component with the resource. this will also clear any timeouts
     // for removing the resource.
-    loadedResources.map(
-      ([, config]) => ModelCache.register(getCacheKey(config), componentRef.current)
-    );
+    loadedResources.forEach(([, config]) => {
+      var cacheKey = getCacheKey(config);
+
+      ModelCache.register(cacheKey, componentRef.current);
+      // make sure we add any provided props for serial requests
+      provideProps(ModelCache.get(cacheKey), config.provides, props, setResourceState);
+    });
 
     // NOTE: changing this to resourcesToFetch causes some inexplicable bugs around cached resources
     // and a UI that wouldn't update. so this is kept as resourcesToUpdate and fetchResources is
@@ -876,18 +880,7 @@ function fetchResources(resources, props, {
           // don't continue unless component is still mounted and resource is current
           if (isCurrentResource([name, config], cacheKey)) {
             // add any dependencies this resource might provide for other resources
-            if (Object.entries(provides).length) {
-              setResourceState((state) => ({
-                ...state,
-                ...Object.entries(provides).reduce((memo, [provide, transform]) => Object.assign({
-                  memo,
-                  ...(provide === SPREAD_PROVIDES_CHAR ?
-                    transform(model, props) :
-                    {[provide]: transform(model, props)})
-                }), {})
-              }));
-            }
-
+            provideProps(model, provides, props, setResourceState);
             onRequestSuccess(model, status, [name, config]);
           }
         },
@@ -903,4 +896,26 @@ function fetchResources(resources, props, {
       );
     })
   );
+}
+
+/**
+ * Add any dependencies that the model provides as resource state.
+ *
+ * @param {Model|Collection} model
+ * @param {object} provides - config provides object
+ * @param {object} props - current component props
+ * @param {function} setResourceState - updates resource state
+ */
+function provideProps(model, provides={}, props, setResourceState) {
+  if (Object.entries(provides).length) {
+    setResourceState((state) => ({
+      ...state,
+      ...Object.entries(provides).reduce((memo, [provide, transform]) => Object.assign({
+        memo,
+        ...(provide === SPREAD_PROVIDES_CHAR ?
+          transform(model, props) :
+          {[provide]: transform(model, props)})
+      }), {})
+    }));
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": ["declarative data-fetching framework", "react"],

--- a/test/use-resources.test.jsx
+++ b/test/use-resources.test.jsx
@@ -882,6 +882,19 @@ describe('useResources', () => {
       await waitsFor(() => dataChild.props.hasLoaded);
     });
 
+    it('has its provided prop provided even when cached', async() => {
+      await waitsFor(() => requestSpy.mock.calls.length);
+      requestSpy.mockClear();
+      unmountAndClearModelCache();
+      ModelCache.put('actions', new Model());
+
+      dataChild = findDataChild(renderUseResources({serial: true}));
+      await waitsFor(() => requestSpy.mock.calls.length);
+      await waitsFor(() => dataChild.props.serialProp);
+      expect(requestSpy.mock.calls.pop()[0]).toMatch(/decisionLogs/);
+      await waitsFor(() => dataChild.props.hasLoaded);
+    });
+
     it('reverts back to pending state if its dependencies are removed', async() => {
       await waitsFor(() => dataChild.props.serialProp);
       expect(isLoading(dataChild.props.decisionLogsLoadingState)).toBe(true);


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
Fixes an issue where cached resources that provided props were not getting the provided props added.
