### PR TITLE
Sync types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -187,7 +187,6 @@ declare module 'resourcerer' {
     dependsOn?: string[];
     force?: boolean;
     lazy?: boolean;
-    modelKey?: ResourceKeys;
     noncritical?: boolean;
     options?: {[key: string]: any};
     params?: {[key: string]: any};
@@ -202,7 +201,9 @@ declare module 'resourcerer' {
   export type ExecutorFunction = (
     ResourceKeys_: ResourceKeys,
     props: {[key: string]: any}
-  ) => Partial<Record<ResourceValues, ResourceConfigObj>>;
+  // return type either has a resource key as the object key or is just a string with a modelKey property
+  ) => Partial<Record<ResourceValues, ResourceConfigObj>> |
+  Partial<Record<string, ResourceConfigObj & {modelKey: ResourceValues}>>;
 
   type WithModelSuffix<K, C> = C extends Collection ? `${K}Collection` : `${K}Model`;
 
@@ -214,8 +215,6 @@ declare module 'resourcerer' {
     WithModelSuffix<Key, InstanceType<ModelMap[InvertedResourceKeys[Key]]>>]:
       InstanceType<ModelMap[InvertedResourceKeys[Key]]>
   };
-
-  type test = ReturnType<ExecutorFunction>;
 
   export interface ModelCache {
     get(key: string): Model | Collection | undefined;

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,8 @@ declare module 'resourcerer' {
     method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
     params?: Record<string, any>;
     url?: string;
+    // they are free to add any other options they like
+    [key: string]: any;
   };
 
   type SetOptions = {
@@ -50,6 +52,8 @@ declare module 'resourcerer' {
 
     save(attrs: Partial<T>, options?: {wait?: boolean; patch?: boolean;} & SyncOptions & SetOptions):
       Promise<[Model<T>, Response]>;
+
+    sync(model: Model<T>, options?: SyncOptions): Promise<[any, Response]>;
 
     destroy(options?: {wait?: boolean} & SyncOptions & SetOptions): Promise<[Model<T>, Response]>;
 
@@ -120,6 +124,8 @@ declare module 'resourcerer' {
 
     slice(start: number, end?: number): ModelArg<T>[];
 
+    sync(collection: Collection<T>, options?: SyncOptions): Promise<[any, Response]>;
+
     parse(response: Record<string, any> | any[], options?: Record<string, any>): Array<T>;
 
     create(
@@ -173,6 +179,8 @@ declare module 'resourcerer' {
   declare function haveAnyErrored(loadingStates: LoadingTypes | LoadingTypes[]): boolean;
   declare function areAnyLoading(loadingStates: LoadingTypes | LoadingTypes[]): boolean;
   declare function areAnyPending(loadingStates: LoadingTypes | LoadingTypes[]): boolean;
+
+  declare function sync(model: Model | Collection, options?: SyncOptions): Promise<[any, Response]>;
 
   type ResourceConfigObj = {
     data?: {[key: string]: any};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": ["declarative data-fetching framework", "react"],


### PR DESCRIPTION
## Description of Proposed Changes:  

More Typescript updates:
  - Add a type for the `sync` module and the `sync` model/collection properties
  - `SyncOptions` can accept any additional key/value pairs 
  -  Allows for `modelKey` use to request multiple versions of the same model in the same component
