### PR TITLE
Readonly cachekey

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -186,6 +186,7 @@ declare module 'resourcerer' {
     [key: `${string}LoadingState`]: LoadingTypes;
     [key: `${string}Collection`]: Collection;
     [key: `${string}Model`]: Model;
+    [key: `${string}Status`]: number;
   }
 
   declare function haveAllLoaded(loadingStates: LoadingTypes | LoadingTypes[]): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,13 +64,13 @@ declare module 'resourcerer' {
 
     toJSON(): T;
 
-    url(urlOptions?: Omit<O, keyof SetOptions>): string;
+    url(urlOptions?: this["urlOptions"]): string;
 
-    urlRoot(urlOptions?: Omit<O, keyof SetOptions>): string;
-
-    urlOptions: Omit<O, keyof SetOptions>;
+    urlRoot(urlOptions?: this["urlOptions"]): string;
 
     collection?: Collection;
+
+    readonly urlOptions: Omit<O, keyof SetOptions>;
 
     readonly cacheKey: string = null;
 
@@ -144,9 +144,9 @@ declare module 'resourcerer' {
 
     fetch(options?: {parse?: boolean} & SyncOptions & CSetOptions): Promise<[Collection<T>, Response]>;
 
-    url(urlOptions?: Omit<O, keyof CSetOptions>): string;
+    url(urlOptions?: this["urlOptions"]): string;
 
-    urlOptions: Omit<O, keyof CSetOptions>;
+    readonly urlOptions: Omit<O, keyof CSetOptions>;
 
     readonly cacheKey: string = null;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,8 +28,11 @@ declare module 'resourcerer' {
     silent?: boolean;
   };
 
-  declare class Model<T extends Record<string, any> = {[key: string]: any}> {
-    constructor(attrs?: T, options?: Record<string, any> & SetOptions): Model;
+  declare class Model<
+    T extends Record<string, any> = {[key: string]: any},
+    O extends Record<string, any> & SetOptions = {[key: string]: any}
+  > {
+    constructor(attrs?: T, options?: O): Model<T, O>;
 
     // TODO: need to reference idAttribute here
     id: T extends {id: string} ? string : string | undefined;
@@ -61,9 +64,15 @@ declare module 'resourcerer' {
 
     toJSON(): T;
 
-    url(urlOptions?: Record<string, any>): string;
+    url(urlOptions?: Omit<O, keyof SetOptions>): string;
 
-    urlRoot(urlOptions?: Record<string, any>): string;
+    urlRoot(urlOptions?: Omit<O, keyof SetOptions>): string;
+
+    urlOptions: Omit<O, keyof SetOptions>;
+
+    collection?: Collection;
+
+    readonly cacheKey: string = null;
 
     static cacheFields: Array<string | ((attrs: T) => Record<string, any>)>;
 
@@ -85,7 +94,7 @@ declare module 'resourcerer' {
     constructor(
       models?: ModelArg<T> | ModelArg<T>[],
       options?: O
-    ): Collection<T>;
+    ): Collection<T, O>;
 
     length: number;
 
@@ -135,7 +144,11 @@ declare module 'resourcerer' {
 
     fetch(options?: {parse?: boolean} & SyncOptions & CSetOptions): Promise<[Collection<T>, Response]>;
 
-    url(urlOptions?: O): string;
+    url(urlOptions?: Omit<O, keyof CSetOptions>): string;
+
+    urlOptions: Omit<O, keyof CSetOptions>;
+
+    readonly cacheKey: string = null;
 
     static cacheFields: Array<string | ((attrs: T) => Record<string, any>)>;
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -27,7 +27,7 @@ export default class Collection {
    *   * comparator {function|string} - dynamically overrides the static comparator property used to
    *     sort the collection
    */
-  constructor(models, options={}) {
+  constructor(models, options={}, cacheKey) {
     const RESERVED_OPTION_KEYS = ['Model', 'comparator', 'silent', 'parse'];
 
     this.Model = options.Model || this._getModelClass();
@@ -35,13 +35,17 @@ export default class Collection {
 
     this._reset();
 
+    if (cacheKey) {
+      this.cacheKey = cacheKey;
+    }
+
     this.urlOptions = Object.keys(options).reduce((memo, key) => Object.assign(
       memo,
       !RESERVED_OPTION_KEYS.includes(key) ? {[key]: options[key]} : {}
     ), {});
 
     if (models) {
-      // silent for completeness, i guess. but a nothing triggered here because it's impossible for
+      // silent for completeness, i guess. but nothing triggered here because it's impossible for
       // a listener to have been attached at this point
       this.reset(models, {silent: true, ...options});
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -35,12 +35,16 @@ export default class Model {
    *   * collection {Collection} - links this model to a collection, if applicable
    *   * ...any other options that .set() takes
    */
-  constructor(attributes={}, options={}) {
+  constructor(attributes={}, options={}, cacheKey) {
     this.cid = uniqueId('c');
     this.attributes = {};
 
     if (options.collection) {
       this.collection = options.collection;
+    }
+
+    if (cacheKey) {
+      this.cacheKey = cacheKey;
     }
 
     if (options.parse) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -64,7 +64,7 @@ export default (key, Model, options={}) => {
   if (!loadingCache[key]) {
     _promise = new Promise((resolve, reject) => {
       if (!model || model.lazy || options.force) {
-        model = model || new Model(options.data, options.options);
+        model = model || new Model(options.data, options.options, key);
 
         if (options.fetch && !options.lazy) {
           addToLoadingCache = true;

--- a/test/collection.test.js
+++ b/test/collection.test.js
@@ -50,6 +50,14 @@ describe('Collection', () => {
     expect(collection.toJSON()).toEqual([]);
   });
 
+  it('gets a cacheKey assigned to a `cacheKey` property if passed', () => {
+    collection = new Collection;
+    expect(collection.cacheKey).not.toBeDefined();
+
+    collection = new Collection({}, {}, 'key_12345');
+    expect(collection.cacheKey).toEqual('key_12345');
+  });
+
   it('urlOptions get passed down to models', async() => {
     collection = new Collection([{id: '1'}], {one: 1, two: 2, comparator: 'foo', parse: true});
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -41,6 +41,14 @@ describe('Model', () => {
     expect(model.collection).toEqual(collection);
   });
 
+  it('gets a cacheKey assigned to a `cacheKey` property if passed', () => {
+    model = new Model;
+    expect(model.cacheKey).not.toBeDefined();
+
+    model = new Model({}, {}, 'key_12345');
+    expect(model.cacheKey).toEqual('key_12345');
+  });
+
   it('parses its attributes before being set if passed a `parse: true` option', () => {
     class _Model extends Model {
       parse(attrs) {


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

## Description of Proposed Changes:  
  -  Adds a `readonly` cacheKey for a model and collection, which is rarely useful but one way to ensure that the model you have corresponds with current data, especially when fetching dependent resources.
  -  Adds types for the `Model.prototype.collection` property and the `*Status` useResources response
  -  Adds the `urlOptions` property, though it shouldn't need to be used.
