### PR TITLE
return cached models and loading state changes immediately

### DIFF
--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -99,6 +99,13 @@ export const useResources = (getResources, props) => {
       // renders. using this reference will guarantee that we always remove listeners from the
       // correct models before attaching new listeners
       listenedModelsRef = useRef([]),
+      // when props change and we have models ready in the cache, we set model state in the render
+      // process. that means we re-run this function without calling any useEffect callbacks. since
+      // prevProps will not (and should not) have changed, the same models that we're to be updated
+      // as state in the first render phase would also be up for update in the next one. so we have
+      // to keep track of which models have been updated in state, and then we'll reset this when
+      // useEffect is finally called.
+      cachedModelsSinceLastEffect = useRef({}),
 
       forceUpdate = useForceUpdate(),
 
@@ -117,51 +124,57 @@ export const useResources = (getResources, props) => {
               // make sure if we were lazy and are no longer lazy (from the same component) that we
               // get included in the list to get updated (and vice versa)
               (prevConfig?.lazy !== config.lazy));
-          });
+          }),
 
-  /**
-   * Fetch things.
-   * Ideally we would re-run this if any of the cache keys have changed, but
-   * right now useEffect can't be run in a dynamic loop--it must be top-level.
-   * So we must manually compare prevProps.
-   *
-   * Note also that every time we set a state, whether it be loading states or models, we are
-   * setting a new object as that state and we will re-render. That means that if a model is cached
-   * or its loading states haven't changed we should _not_ just go ahead and call fetchResources,
-   * because that will re-render our components an additional two times.
-   */
-  useEffect(() => {
-    var pendingResources = resources.filter(not(hasAllDependencies.bind(null, props)))
-            .filter(([, config]) =>
-              !prevPropsRef.current || hasAllDependencies(prevPropsRef.current, [, config])),
-        resourcesToUpdate = getResourcesToUpdate(resources),
-        nextLoadingStates = {
-          ...buildResourcesLoadingState(pendingResources, props, LoadingStates.PENDING),
-          // but resourcesToUpdate should get set to LOADING (or LOADED if in the cache)
-          ...buildResourcesLoadingState(resourcesToUpdate.filter(withoutPrefetch), props)
-        },
+      // every time we call this, we remove all previous listeners and attach new ones based on the
+      // current models used by the component.
+      attachModelListeners = () => {
+        // only get those from the cache. models in state might can empty models, but even so i
+        // think it would be preferable to use state (within a separate useEffect) to determine
+        // which models get listened to. but as mentioned, that would require the effect to depend
+        // on cache keys, which are dynamic, and effects can't have dynamic dependencies right now
+        let listenedModels = resources.map(([, config]) => getModelFromCache(config))
+            .filter(Boolean);
 
-        // separate out those resources to update into those that are already cached and those
-        // that need to be fetched. the former will get the models updated immediately
-        [loadedResources, resourcesToFetch] = partitionResources(
-          resourcesToUpdate,
-          nextLoadingStates
-        );
+        // remove previous listeners and attach new ones
+        listenedModelsRef.current.forEach((model) => model.offUpdate(componentRef.current));
+        listenedModels.forEach((model) => model.onUpdate(forceUpdate, componentRef.current));
 
-    // first set our updated resources' loading states to LOADING. but don't set if we're already
-    // in a loading state for that resource, because that's a pointless extra render. also, any
-    // resources that have lost their dependencies should go back to a pending state
-    if (Object.keys(nextLoadingStates).some((ky) => nextLoadingStates[ky] !== loadingStates[ky])) {
-      loaderDispatch({type: LoadingStates.LOADING, payload: nextLoadingStates});
-    }
+        listenedModelsRef.current = listenedModels;
+      },
 
-    // pending resources: need to remove our model state here because it won't happen after a
-    // request like the others, since no request is being made for pending resources. note that
-    // this will stay as the requested model if the dependent prop does not affect the cache key.
-    // loaded resources: we also don't fetch these, so we need to set our models immediately
-    if (pendingResources.concat(loadedResources).length) {
-      setModels(modelAggregator(pendingResources.concat(loadedResources).filter(withoutPrefetch)));
-    }
+      // this should be for NEW pending resources only, not ones set in initial loading state
+      pendingResources = resources.filter(not(hasAllDependencies.bind(null, props)))
+          .filter(([, config]) =>
+            prevPropsRef.current && hasAllDependencies(prevPropsRef.current, [, config])),
+      resourcesToUpdate = getResourcesToUpdate(resources),
+      nextLoadingStates = {
+        ...buildResourcesLoadingState(pendingResources, props, LoadingStates.PENDING),
+        // but resourcesToUpdate should get set to LOADING (or LOADED if in the cache)
+        ...buildResourcesLoadingState(resourcesToUpdate.filter(withoutPrefetch), props)
+      },
+
+      // separate out those resources to update into those that are already cached and those
+      // that need to be fetched. the former will get the models updated immediately
+      [loadedResources, resourcesToFetch] = partitionResources(
+        resourcesToUpdate,
+        nextLoadingStates
+      ),
+
+      // "cached" is a misnomer...
+      cachedResources = pendingResources.concat(loadedResources)
+          .filter(([name]) => !cachedModelsSinceLastEffect.current[name]);
+
+  // here we set any newly-pending resources as well as any already-loaded resources as model state,
+  // short-circuiting the render cycle since this update happens in the render phase. this is a
+  // critical piece of useResources because it means that models, dependent models, and also loading
+  // states (next block of code) get updated immediately with no extra 'in-between' blips on the
+  // screen.
+  if (cachedResources.length) {
+    setModels(modelAggregator(cachedResources));
+    cachedResources.forEach(([name, config]) => {
+      cachedModelsSinceLastEffect.current[name] = true;
+    });
 
     // because we don't go through the request module for normal-flow resources that are cached,
     // we need to re-register this component with the resource. this will also clear any timeouts
@@ -170,10 +183,32 @@ export const useResources = (getResources, props) => {
       var cacheKey = getCacheKey(config);
 
       ModelCache.register(cacheKey, componentRef.current);
-      // make sure we add any provided props for serial requests
+      // make sure we add any provided props for serial requests. when this function rerenders any
+      // cached dependent models will also trigger a setModels call and an additional re-render
+      // without a useEffect
       provideProps(ModelCache.get(cacheKey), config.provides, props, setResourceState);
     });
 
+    // make sure if we bypass fetching because of cached models that we attach fresh listeners
+    attachModelListeners();
+  }
+
+  // set our updated resources' loading states to LOADING. but don't set if we're already in a
+  // loading state for that resource, because that's a pointless extra render. also, any resources
+  // that have lost their dependencies should go back to a pending state.
+  if (Object.keys(nextLoadingStates).some((ky) => nextLoadingStates[ky] !== loadingStates[ky])) {
+    loaderDispatch({type: LoadingStates.LOADING, payload: nextLoadingStates});
+  }
+
+  /**
+   * Fetch things.
+   *
+   * Note also that every time we set a state, whether it be loading states or models, we are
+   * setting a new object as that state and we will re-render. That means that if a model is cached
+   * or its loading states haven't changed we should _not_ just go ahead and call fetchResources,
+   * because that will re-render our components an additional two times.
+   */
+  useEffect(() => {
     // NOTE: changing this to resourcesToFetch causes some inexplicable bugs around cached resources
     // and a UI that wouldn't update. so this is kept as resourcesToUpdate and fetchResources is
     // given resourcesToFetch. Because we are still only fetching resourcesToFetch and because any
@@ -231,23 +266,14 @@ export const useResources = (getResources, props) => {
         }
       }).then(() => {
         if (isMountedRef.current) {
-          // only get those from the cache. models in state might can empty models, but even so i
-          // think it would be preferable to use state (within a separate useEffect) to determine
-          // which models get listened to. but as mentioned, that would require the effect to depend
-          // on cache keys, which are dynamic, and effects can't have dynamic dependencies right now
-          let listenedModels = resources.map(([, config]) => getModelFromCache(config))
-              .filter(Boolean);
-
-          // remove previous listeners and attach new ones
-          listenedModelsRef.current.forEach((model) => model.offUpdate(componentRef.current));
-          listenedModels.forEach((model) => model.onUpdate(forceUpdate, componentRef.current));
-
-          listenedModelsRef.current = listenedModels;
+          attachModelListeners();
         }
       });
     }
 
-    return () => prevPropsRef.current = props;
+    prevPropsRef.current = props;
+    // now we can reset this value
+    cachedModelsSinceLastEffect.current = {};
   });
 
   // this effect attaches listeners to any bypassed models (ie, those passed in) which don't get
@@ -295,19 +321,6 @@ export const useResources = (getResources, props) => {
     ...props[ResourcesConfig.queryParamsPropName] || {},
     ...resourceState,
 
-    // helpers
-    isOrWillBeLoading: () => {
-      var resourcesToUpdate = getResourcesToUpdate(
-        resources.filter(withoutNoncritical).filter(withoutPrefetch)
-      );
-
-      // here we only look at resources to fetch, not loaded ones
-      return !hasLoaded(criticalLoadingStates) || !!partitionResources(
-        resourcesToUpdate,
-        // 'next' loading states
-        buildResourcesLoadingState(resourcesToUpdate, props)
-      )[1].length;
-    },
     refetch: (fn) => {
       var refetches = fn(ResourceKeys);
 
@@ -525,11 +538,11 @@ function findCacheKey(resource, getResources, props) {
  * @param {object} props - current component props
  * @param {LoadingStates} defaultState - state to return if resource already exists in cache;
  *   in most circumstances, this should be the LOADED state as you might expect. However, when we
- *   prep resources to be re-fetched or if models were previously created lazily (without fetching),
- *   in order to keep the loading state in sync with its model state, even a cached resource should
- *   be temporarily in a LOADING state (if cached, this will be corrected in the next microtask and
- *   before the JS stack is completed, so the LOADING state should never be shown in the UI, despite
- *   render being called multiple times).
+ *   prep resources to be re-fetched, they should get put into a loading state. Because we use
+ *   render bailouts to immediately update our loading states, a cached resource that no longer has
+ *   its dependent props will go back to a PENDING state, but that could be just momentarily if the
+ *   dependent prop gets added in a bailout, triggering an immediate re-render phase with no
+ *   painting to screen. Lazy models should always be considered LOADED.
  * @return {object} state object with resource state keys as keys and the loading
  *    state as values
  */
@@ -538,7 +551,11 @@ function buildResourcesLoadingState(resources, props, defaultState=LoadingStates
     [getResourceState(name)]: !config.refetch && (shouldBypassFetch(props, [name, config]) ||
       (getModelFromCache(config) && !getModelFromCache(config).lazy)) ?
       defaultState :
-      (!hasAllDependencies(props, [, config]) ? LoadingStates.PENDING : LoadingStates.LOADING)
+      (!hasAllDependencies(props, [, config]) ? LoadingStates.PENDING : config.lazy ?
+        // any lazy resource should be considered loaded in its resource state, even
+        // though it will temporarily show up in the resourcesToUpdate list
+        LoadingStates.LOADED :
+        LoadingStates.LOADING)
   }), {});
 }
 

--- a/test/use-resources.test.jsx
+++ b/test/use-resources.test.jsx
@@ -891,7 +891,7 @@ describe('useResources', () => {
       dataChild = findDataChild(renderUseResources({serial: true}));
       await waitsFor(() => requestSpy.mock.calls.length);
       await waitsFor(() => dataChild.props.serialProp);
-      expect(requestSpy.mock.calls.pop()[0]).toMatch(/decisionLogs/);
+      expect(requestSpy.mock.calls.some((call) => /decisionLogs/.test(call[0]))).toBe(true);
       await waitsFor(() => dataChild.props.hasLoaded);
     });
 
@@ -1254,24 +1254,6 @@ describe('useResources', () => {
     await waitsFor(() => dataChild.props.hasLoaded);
     expect(Collection.prototype.fetch).toHaveBeenCalledTimes(1);
     expect(Collection.prototype.fetch.mock.instances[0] instanceof DecisionsCollection).toBe(true);
-  });
-
-  it('isOrWillBeLoading is true for two cycles that props change and loading starts', async() => {
-    dataChild = findDataChild(renderUseResources());
-
-    expect(dataChild.props.isOrWillBeLoading()).toBe(true);
-    await waitsFor(() => dataChild.props.hasLoaded);
-    expect(dataChild.props.isOrWillBeLoading()).toBe(false);
-
-    dataChild.props.setResourceState({userId: 'alex'});
-    expect(dataChild.props.hasLoaded).toBe(true);
-    expect(dataChild.props.isLoading).toBe(false);
-    expect(dataChild.props.isOrWillBeLoading()).toBe(true);
-
-    await waitsFor(() => !dataChild.props.hasLoaded);
-    expect(dataChild.props.isOrWillBeLoading()).toBe(true);
-    await waitsFor(() => dataChild.props.hasLoaded);
-    expect(dataChild.props.isOrWillBeLoading()).toBe(false);
   });
 });
 

--- a/test/with-resources.test.jsx
+++ b/test/with-resources.test.jsx
@@ -1291,24 +1291,6 @@ describe('withResources', () => {
     expect(Collection.prototype.fetch).toHaveBeenCalledTimes(1);
     expect(Collection.prototype.fetch.mock.instances[0] instanceof DecisionsCollection).toBe(true);
   });
-
-  it('isOrWillBeLoading is true for two cycles that props change and loading starts', async() => {
-    dataChild = findDataChild(renderWithResources());
-
-    expect(dataChild.props.isOrWillBeLoading()).toBe(true);
-    await waitsFor(() => dataChild.props.hasLoaded);
-    expect(dataChild.props.isOrWillBeLoading()).toBe(false);
-
-    dataChild.props.setResourceState({userId: 'alex'});
-    expect(dataChild.props.hasLoaded).toBe(true);
-    expect(dataChild.props.isLoading).toBe(false);
-    expect(dataChild.props.isOrWillBeLoading()).toBe(true);
-
-    await waitsFor(() => !dataChild.props.hasLoaded);
-    expect(dataChild.props.isOrWillBeLoading()).toBe(true);
-    await waitsFor(() => dataChild.props.hasLoaded);
-    expect(dataChild.props.isOrWillBeLoading()).toBe(false);
-  });
 });
 
 /**


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
- Fixes a long standing (since the introduction of the `useResources` hook from the `withResources HOC) issue with the number of render calls required to change loading states. Instead of waiting to make loading state or cached model state changes in the `useEffect` (the following frame post painting to screen, triggering an additional render cycle), we use [render bailouts](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) to return the updated state immediately before moving on to effects.


## Description of Proposed Changes:  
  -  Moves `setModels` and `loaderDispatch` calls outside the `useEffect` and into the render phase. `useEffect` is only for the fetch calls now (and still fake-fetching lazy resources).
  -  Attaching listeners happens now anytime `setModels` is called
  -  `pendingResources` are only calculated for _changes_ in the component to become pending because any initial pending resources will already get set when mounted
  - `isOrWillBeLoading` helper is removed
  - introduces a `cachedModelsSinceLastEffect` ref to keep track of the models that have been updated in the render phase to avoid infinite loops
  - `lazy` models are always considered `LOADED`
