### PR TITLE
bring back force fetch on mount

### DIFF
--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -44,8 +44,8 @@ const SPREAD_PROVIDES_CHAR = '_';
  *        a value to be set for the prop. If the key is equal to
  *        SPREAD_PROVIDES_CHAR, then the return value of the transform function
  *        is spread for dynamically-provided props.
- *   * force {boolean} - force a fetch request regardless of whether the model
- *        is already in the cache
+ *   * force {boolean} - force a fetch request on mount regardless of whether the
+ *        model is already in the cache
  *   * prefetch {object} - an individual map of expected future props to fetch
  *        a new resource and store it in the cache. it will not, however, get
  *        passed down to the child (no loading states, either)
@@ -111,7 +111,10 @@ export const useResources = (getResources, props) => {
 
       // note that this only tells when cache keys have changed. if a resource has already been
       // cached, this will still return its resource when the component mounts. that's why we
-      // partition these out later into loaded and not loaded resources
+      // partition these out later into loaded and not loaded resources.
+      //
+      // for a similar reason, forced resources get returned here on mount and not afterwards.
+      // we prevent them from getting set to a LOADED state which forces them to get fetched.
       getResourcesToUpdate = (rsrcs) => rsrcs.filter(hasAllDependencies.bind(null, props))
           .filter(not(shouldBypassFetch.bind(null, props)))
           .filter(([name, config]) => {
@@ -151,7 +154,13 @@ export const useResources = (getResources, props) => {
       nextLoadingStates = {
         ...buildResourcesLoadingState(pendingResources, props, LoadingStates.PENDING),
         // but resourcesToUpdate should get set to LOADING (or LOADED if in the cache)
-        ...buildResourcesLoadingState(resourcesToUpdate.filter(withoutPrefetch), props)
+        ...buildResourcesLoadingState(
+          // removing forced resources here ensures that they stay in a LOADING state and thus
+          // get partitioned into resourcesToFetch. this only happens on mount; on update, they
+          // don't ever get included in resourcesToUpdate
+          resourcesToUpdate.filter(withoutPrefetch).filter(withoutForced),
+          props
+        )
       },
 
       // separate out those resources to update into those that are already cached and those
@@ -548,7 +557,8 @@ function findCacheKey(resource, getResources, props) {
  */
 function buildResourcesLoadingState(resources, props, defaultState=LoadingStates.LOADED) {
   return resources.reduce((state, [name, config]) => Object.assign(state, {
-    [getResourceState(name)]: !config.refetch && (shouldBypassFetch(props, [name, config]) ||
+    [getResourceState(name)]: !config.refetch && !config.force &&
+      (shouldBypassFetch(props, [name, config]) ||
       (getModelFromCache(config) && !getModelFromCache(config).lazy)) ?
       defaultState :
       (!hasAllDependencies(props, [, config]) ? LoadingStates.PENDING : config.lazy ?
@@ -603,6 +613,16 @@ function withoutPrefetch([, config]) {
  */
 function withoutNoncritical([, config]) {
   return !config.noncritical;
+}
+
+/**
+ * Filter predicate to remove forced resources from a resources list.
+ *
+ * @param {[, object]} config - resources config entry
+ * @return {boolean} true if a resource is not forced
+ */
+function withoutForced([, config]) {
+  return !config.force;
 }
 
 /**
@@ -739,8 +759,8 @@ function modelAggregator(resources) {
  */
 function partitionResources(resourcesToUpdate, loadingStates) {
   return resourcesToUpdate.reduce((memo, [name, config]) =>
-    config.refetch || config.prefetch || !hasLoaded(loadingStates[getResourceState(name)]) ||
-      getModelFromCache(config)?.lazy ?
+    config.refetch || config.force || config.prefetch ||
+    !hasLoaded(loadingStates[getResourceState(name)]) || getModelFromCache(config)?.lazy ?
       [memo[0], memo[1].concat([[name, config]])] :
       [memo[0].concat([[name, config]]), memo[1]],
   [[], []]);


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
There are just times when you want to make sure you fetch the latest resource regardless of whether or not it's in the cache. When a component is mounted, you can use [refetch](https://github.com/noahgrant/resourcerer?tab=readme-ov-file#refetching). But currently there is no good way to force fetch a resource when a component mounts.


## Description of Proposed Changes:  
  -  Here we bring back an old `force: true` config flag that will force fetch a resource when its component mounts (it will have no effect on re-renders after mounting). If the component unmounts and mounts again, it will continue to force fetch as long as the `force` flag is true. It is up to the client component to control when the force flag is on.

