### PR TITLE
refetching notifies components

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -76,7 +76,6 @@ export default (key, Model, options={}) => {
               // components that call non-lazy version of the resource all get put into a
               // loading state
               delete model.lazy;
-              delete model.refetching;
 
               ModelCache.put(key, newModel, options.component);
               resolve([newModel, response?.status]);

--- a/lib/request.js
+++ b/lib/request.js
@@ -69,12 +69,6 @@ export default (key, Model, options={}) => {
         if (options.fetch && !options.lazy) {
           addToLoadingCache = true;
 
-          if (options.refetch) {
-            model.refetching = options.component;
-            // this will cause any client components to re-render in a loading state
-            model.triggerUpdate();
-          }
-
           model.fetch({params: options.params}).then(
             ([newModel, response]) => {
               delete loadingCache[key];

--- a/lib/request.js
+++ b/lib/request.js
@@ -69,6 +69,12 @@ export default (key, Model, options={}) => {
         if (options.fetch && !options.lazy) {
           addToLoadingCache = true;
 
+          if (options.refetch) {
+            model.refetching = options.component;
+            // this will cause any client components to re-render in a loading state
+            model.triggerUpdate();
+          }
+
           model.fetch({params: options.params}).then(
             ([newModel, response]) => {
               delete loadingCache[key];
@@ -76,6 +82,7 @@ export default (key, Model, options={}) => {
               // components that call non-lazy version of the resource all get put into a
               // loading state
               delete model.lazy;
+              delete model.refetching;
 
               ModelCache.put(key, newModel, options.component);
               resolve([newModel, response?.status]);

--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -177,11 +177,10 @@ export const useResources = (getResources, props) => {
       resourcesToRefetch = resources.filter(([name, config]) => {
         var model = getModelFromCache(config);
 
-        // ensure here that this isn't component where the refetch was triggered (because we already
-        // take care of that cycle) and that we're not already refetching/since calling
-        // setResourceState inside render will trigger an immediate re-render with props.refetches
-        // repopulated before moving from a loaded to loading state.
-        return model?.refetching && model.refetching !== componentRef.current &&
+        // check that we're not already refetching/since calling setResourceState inside render
+        // will trigger an immediate re-render with props.refetches repopulated before moving
+        // from a loaded to loading state.
+        return model?.refetching &&
           !props.refetches?.includes(name) && hasLoaded(loadingStates[getResourceState(name)]);
       }),
 
@@ -354,11 +353,19 @@ export const useResources = (getResources, props) => {
     ...resourceState,
 
     refetch: (fn) => {
-      var refetches = fn(ResourceKeys);
+      fn(ResourceKeys).forEach((name) => {
+        var model = getModelFromCache(findConfig([name, {}], getResources, props));
 
-      if (refetches.length) {
-        setResourceState((state) => ({...state, refetches}));
-      }
+        /**
+         * Set a refetching flag on the model and re-render. This will cause all components
+         * that use this model to re-render and add it to their `refetches` list, which will
+         * put it back in a loading state.
+         */
+        if (model) {
+          model.refetching = true;
+          model.triggerUpdate();
+        }
+      });
     },
 
     setResourceState,
@@ -913,7 +920,6 @@ function fetchResources(resources, props, {
         params,
         component,
         force: refetch,
-        refetch,
         ...rest
       }).then(
         // success callback, where we track request time and add any dependent props or models

--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -170,20 +170,6 @@ export const useResources = (getResources, props) => {
         nextLoadingStates
       ),
 
-      // this will be a list of resources that were refetched from another component. the resource
-      // in this component will then get added to the refetches list and go through the same
-      // process (showing its own loading state), except that the refetch will have already been
-      // made so no request gets made
-      resourcesToRefetch = resources.filter(([name, config]) => {
-        var model = getModelFromCache(config);
-
-        // check that we're not already refetching/since calling setResourceState inside render
-        // will trigger an immediate re-render with props.refetches repopulated before moving
-        // from a loaded to loading state.
-        return model?.refetching &&
-          !props.refetches?.includes(name) && hasLoaded(loadingStates[getResourceState(name)]);
-      }),
-
       // "cached" is a misnomer...
       cachedResources = pendingResources.concat(loadedResources)
           .filter(([name]) => !cachedModelsSinceLastEffect.current[name]);
@@ -321,25 +307,6 @@ export const useResources = (getResources, props) => {
     };
   }, []);
 
-  /**
-   * If we are refetching a resource from another component, add it to this component's refetches
-   * so that we display a loading state here, as well.
-   */
-  if (resourcesToRefetch.length) {
-    setResourceState((state) => ({...state, refetches: resourcesToRefetch.map(([name]) => name)}));
-  }
-
-  /**
-   * This effect promptly removes any entries placed in the `refetches` resources state array.
-   * Doing this here ensures that we don't have repeated effects with refetches, since that passes
-   * them through the `resourcesToUpdate` path.
-   */
-  useEffect(() => {
-    if ((props.refetches || []).length) {
-      setResourceState(({refetches, ...state}) => state);
-    }
-  }, [(props.refetches || []).join()]);
-
   currentPropsRef.current = props;
 
   return {
@@ -358,8 +325,7 @@ export const useResources = (getResources, props) => {
 
         /**
          * Set a refetching flag on the model and re-render. This will cause all components
-         * that use this model to re-render and add it to their `refetches` list, which will
-         * put it back in a loading state.
+         * that use this model to re-render and put it back in a loading state.
          */
         if (model) {
           model.refetching = true;
@@ -427,7 +393,7 @@ function generateResources(getResources, props) {
       .reduce((memo, [name, config={}]) =>
         memo.concat([[name, {
           modelKey: config.modelKey || name,
-          refetch: props.refetches?.includes(name),
+          refetch: !!getModelFromCache({...config, modelKey: config.modelKey || name})?.refetching,
           ...config
         }]].concat(
           // expand prefetched resources with their own options based on
@@ -927,6 +893,8 @@ function fetchResources(resources, props, {
           if (shouldMeasure) {
             trackRequestTime(name, config);
           }
+
+          delete model.refetching;
 
           // add unfetched resources that a model might provide
           if (ModelMap[modelKey].providesModels) {

--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -106,6 +106,7 @@ export const useResources = (getResources, props) => {
       // to keep track of which models have been updated in state, and then we'll reset this when
       // useEffect is finally called.
       cachedModelsSinceLastEffect = useRef({}),
+      refetchedModelsSinceLastEffect = useRef({}),
 
       forceUpdate = useForceUpdate(),
 
@@ -123,7 +124,13 @@ export const useResources = (getResources, props) => {
                 previousCacheKey = prevConfig && getCacheKey(prevConfig);
 
             return (!previousCacheKey || previousCacheKey !== getCacheKey(config) ||
-              !hasAllDependencies(prevPropsRef.current, [, config]) || config.refetch ||
+              !hasAllDependencies(prevPropsRef.current, [, config]) ||
+              // we only want to refetch if the resource is currently in a loaded state. but then
+              // we'll move to a loading state and short-circuit the render cycle, and it won't be
+              // loaded in the next cycle. that's why we use the ref, as well
+              (config.refetch &&
+                (hasLoaded(loadingStates[getResourceState(name)]) ||
+                  refetchedModelsSinceLastEffect.current[name])) ||
               // make sure if we were lazy and are no longer lazy (from the same component) that we
               // get included in the list to get updated (and vice versa)
               (prevConfig?.lazy !== config.lazy));
@@ -202,6 +209,14 @@ export const useResources = (getResources, props) => {
     attachModelListeners();
   }
 
+  // register any refetched items in the ref so that when we short-circuit the render we still
+  // know which ones we need to fetch
+  resourcesToFetch.forEach(([name, config]) => {
+    if (config.refetch) {
+      refetchedModelsSinceLastEffect.current[name] = true;
+    }
+  });
+
   // set our updated resources' loading states to LOADING. but don't set if we're already in a
   // loading state for that resource, because that's a pointless extra render. also, any resources
   // that have lost their dependencies should go back to a pending state.
@@ -263,7 +278,7 @@ export const useResources = (getResources, props) => {
         onRequestFailure: (status, [name, config]) => {
           ReactDOM.unstable_batchedUpdates(() => {
             // request failed, which means this model should not be in the cache. but we still want
-            // to // set our model state so that when we go back into a loading state, the empty
+            // to set our model state so that when we go back into a loading state, the empty
             // model is present instead of any previously-loaded model
             setModels(modelAggregator([[name, config]]));
 
@@ -281,8 +296,9 @@ export const useResources = (getResources, props) => {
     }
 
     prevPropsRef.current = props;
-    // now we can reset this value
+    // now we can reset these values
     cachedModelsSinceLastEffect.current = {};
+    refetchedModelsSinceLastEffect.current = {};
   });
 
   // this effect attaches listeners to any bypassed models (ie, those passed in) which don't get
@@ -320,17 +336,21 @@ export const useResources = (getResources, props) => {
     ...resourceState,
 
     refetch: (fn) => {
-      fn(ResourceKeys).forEach((name) => {
-        var model = getModelFromCache(findConfig([name, {}], getResources, props));
+      ReactDOM.unstable_batchedUpdates(() => {
+        fn(ResourceKeys).forEach((name) => {
+          var model = getModelFromCache(
+            findConfig([name, {}], getResources, props)
+          );
 
-        /**
-         * Set a refetching flag on the model and re-render. This will cause all components
-         * that use this model to re-render and put it back in a loading state.
-         */
-        if (model) {
-          model.refetching = true;
-          model.triggerUpdate();
-        }
+          /**
+           * Set a refetching flag on the model and re-render. This will cause all components
+           * that use this model to re-render and put it back in a loading state.
+           */
+          if (model) {
+            model.refetching = true;
+            model.triggerUpdate();
+          }
+        });
       });
     },
 
@@ -927,6 +947,10 @@ function fetchResources(resources, props, {
 
         // error callback
         (status) => {
+          // if a refetching request errors, we still want to remove the refetching flag
+          // before going into an error state
+          delete getModelFromCache(config)?.refetching;
+
           // this catch block gets called _only_ for request errors.
           // don't set error state unless resource is current
           if (isCurrentResource([name, config], cacheKey)) {

--- a/lib/resourcerer.js
+++ b/lib/resourcerer.js
@@ -170,6 +170,21 @@ export const useResources = (getResources, props) => {
         nextLoadingStates
       ),
 
+      // this will be a list of resources that were refetched from another component. the resource
+      // in this component will then get added to the refetches list and go through the same
+      // process (showing its own loading state), except that the refetch will have already been
+      // made so no request gets made
+      resourcesToRefetch = resources.filter(([name, config]) => {
+        var model = getModelFromCache(config);
+
+        // ensure here that this isn't component where the refetch was triggered (because we already
+        // take care of that cycle) and that we're not already refetching/since calling
+        // setResourceState inside render will trigger an immediate re-render with props.refetches
+        // repopulated before moving from a loaded to loading state.
+        return model?.refetching && model.refetching !== componentRef.current &&
+          !props.refetches?.includes(name) && hasLoaded(loadingStates[getResourceState(name)]);
+      }),
+
       // "cached" is a misnomer...
       cachedResources = pendingResources.concat(loadedResources)
           .filter(([name]) => !cachedModelsSinceLastEffect.current[name]);
@@ -306,6 +321,14 @@ export const useResources = (getResources, props) => {
           .forEach((model) => model.offUpdate(componentRef.current));
     };
   }, []);
+
+  /**
+   * If we are refetching a resource from another component, add it to this component's refetches
+   * so that we display a loading state here, as well.
+   */
+  if (resourcesToRefetch.length) {
+    setResourceState((state) => ({...state, refetches: resourcesToRefetch.map(([name]) => name)}));
+  }
 
   /**
    * This effect promptly removes any entries placed in the `refetches` resources state array.
@@ -890,6 +913,7 @@ function fetchResources(resources, props, {
         params,
         component,
         force: refetch,
+        refetch,
         ...rest
       }).then(
         // success callback, where we track request time and add any dependent props or models

--- a/test/with-resources.test.jsx
+++ b/test/with-resources.test.jsx
@@ -501,7 +501,7 @@ describe('withResources', () => {
     });
 
   it('passes a false \'fetch\' option if the model key is of an unfetched model', async() => {
-    requestSpy.mockResolvedValue([]);
+    requestSpy.mockResolvedValue([{}]);
     dataChild = findDataChild(renderWithResources({unfetch: true}));
 
     await waitsFor(() => requestSpy.mock.calls.length);
@@ -1255,16 +1255,64 @@ describe('withResources', () => {
 
     expect(requestSpy.mock.calls.length).toEqual(3);
     dataChild.props.refetch(({DECISIONS, USER}) => [DECISIONS, USER]);
+    dataChild.props.refetch(({DECISIONS, USER}) => [DECISIONS, USER]);
 
     await waitsFor(() => !dataChild.props.hasLoaded);
 
     expect(dataChild.props.decisionsLoadingState).toEqual(LoadingStates.LOADING);
+    expect(dataChild.props.decisionsLoadingState).toEqual(
+      LoadingStates.LOADING
+    );
     expect(dataChild.props.userLoadingState).toBe(LoadingStates.LOADING);
     expect(dataChild.props.analystsLoadingState).toBe(LoadingStates.LOADED);
+    // we can call render again a few times but the request won't get made even
+    // though models still have the refetching flag
+    renderWithResources();
+    renderWithResources();
 
     expect(requestSpy.mock.calls.length).toEqual(5);
 
     await waitsFor(() => dataChild.props.hasLoaded);
+  });
+
+  it('refetching in one component sets loading states in another', async() => {
+    class SecondTestChild extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
+
+    class RefetchWrapper extends React.Component {
+      render() {
+        return (
+          <>
+            <TestComponent />
+            <TestComponent TestChildren={SecondTestChild} />
+          </>
+        );
+      }
+    }
+
+    const refetchWrapper = ReactDOM.render(<RefetchWrapper />, renderNode);
+
+    dataChild = findDataChild(refetchWrapper);
+    const secondChild = findDataChild(refetchWrapper, SecondTestChild);
+
+    await waitsFor(() => dataChild.props.hasLoaded);
+
+    expect(secondChild.props.hasLoaded).toBe(true);
+    dataChild.props.refetch(({DECISIONS}) => [DECISIONS]);
+
+    await waitsFor(() => dataChild.props.isLoading);
+    expect(secondChild.props.isLoading).toBe(true);
+
+    await Promise.all([
+      waitsFor(() => dataChild.props.hasLoaded),
+      waitsFor(() => secondChild.props.hasLoaded)
+    ]);
+
+    // 3 for each component, and then one refetch for each component
+    expect(requestSpy.mock.calls.length).toEqual(8);
   });
 
   it('fetches lazily-cached resources', async() => {


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

Currently, when calling `refetch` from a component, the loading state cycle only happens in the component that calls `refetch`. This change makes any component that relies on that resource respond to a refetch called by any other component in the tree. This will make for a more intuitive user response, since any component that relies on a resource should go into its loading state whenever that resource is updated.

