### PR TITLE
remove cacheFields property

### DIFF
--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -111,9 +111,6 @@ export default class Collection<
    */
   static dependencies: Array<string | ((attrs: Record<string, any>) => Record<string, any>)> = [];
 
-  // deprecated
-  static cacheFields: Array<string | ((attrs: Record<string, any>) => Record<string, any>)> = [];
-
   /**
    * Use this to override the default library-wide cacheTimeout set in the config.
    */

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -99,9 +99,6 @@ export default class Model<
    */
   static dependencies: Array<string | ((attrs: Record<string, any>) => Record<string, any>)> = [];
 
-  // deprecated
-  static cacheFields: Array<string | ((attrs: Record<string, any>) => Record<string, any>)> = [];
-
   /**
    * Use this to override the default library-wide cacheTimeout set in the config.
    */

--- a/lib/resourcerer.ts
+++ b/lib/resourcerer.ts
@@ -552,8 +552,6 @@ function getEmptyModel({ modelKey, data, options }: InternalResourceConfigObj) {
  *   `params` object as a parameter and return a key/value object that gets
  *   flattened to a piece of the cache key.
  *
- * We also support the deprecated `cacheFields` instead.
- *
  * @param {object} config - resource config object (destructured)
  * @return {string} cache key
  */
@@ -565,10 +563,7 @@ export function getCacheKey({
 }: InternalResourceConfigObj) {
   const Constructor = ModelMap[modelKey] as ConstructorTypes;
   const toKeyValString = ([key, val]: [string, any]) => (val ? `${key}=${val}` : ""),
-    dependencies =
-      (Constructor?.dependencies?.length ? Constructor?.dependencies : Constructor?.cacheFields) ||
-      [],
-    fields = dependencies
+    fields = (Constructor?.dependencies || [])
       .map((key) =>
         typeof key === "function" ?
           Object.entries(key(params)).map(toKeyValString).join("_")

--- a/test/model-mocks.ts
+++ b/test/model-mocks.ts
@@ -28,7 +28,7 @@ export class DecisionsCollection extends Collection {
     return "/root/decisions";
   }
 
-  static cacheFields = ["include_deleted"];
+  static dependencies = ["include_deleted"];
 }
 
 export class NotesModel extends Model {
@@ -38,7 +38,7 @@ export class NotesModel extends Model {
     return `/root/${userId}/notes`;
   }
 
-  static cacheFields = ["userId"];
+  static dependencies = ["userId"];
 }
 
 export class SearchQueryModel extends Model {
@@ -84,7 +84,7 @@ export class DecisionLogsCollection extends Collection {
     return "/root/decision_logs";
   }
 
-  static cacheFields = ["logs"];
+  static dependencies = ["logs"];
 }
 
 // next three are unfetched resources

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -28,7 +28,6 @@ describe("Model", () => {
 
   it("has expected default static properties", () => {
     expect(Model.idAttribute).toEqual("id");
-    expect(Model.cacheFields).toEqual([]);
     expect(Model.dependencies).toEqual([]);
     expect(Model.defaults).toEqual({});
   });

--- a/test/prefetch.test.js
+++ b/test/prefetch.test.js
@@ -54,31 +54,6 @@ describe("prefetch", () => {
     UserModel.dependencies = oldFields;
   });
 
-  it("correctly turns the config object into cache key using legacy cacheFields", () => {
-    var oldFields = UserModel.dependencies;
-
-    UserModel.dependencies = [];
-    UserModel.cacheFields = ["userId", "source"];
-
-    prefetch(getResources, expectedProps)(dummyEvt);
-    vi.advanceTimersByTime(100);
-
-    expect(Request.default.mock.calls[0][0]).toEqual("usersource=hbase_userId=noah");
-    expect(Request.default.mock.calls[0][1]).toEqual(UserModel);
-    expect(Request.default.mock.calls[0][2]).toEqual({
-      options: { userId: "noah" },
-      params: { home: "sf", source: "hbase" },
-    });
-
-    expect(Request.default.mock.calls[1][0]).toEqual("decisions");
-    expect(Request.default.mock.calls[1][1]).toEqual(DecisionsCollection);
-    expect(Request.default.mock.calls[1][2]).toEqual({});
-
-    expect(() => prefetch(() => false)({})).not.toThrow();
-    UserModel.cacheFields = [];
-    UserModel.dependencies = oldFields;
-  });
-
   it("will fire if the user hovers over the element for longer than the timeout", () => {
     var leaveEvt = new Event("mouseleave");
 

--- a/test/use-resources.test.jsx
+++ b/test/use-resources.test.jsx
@@ -129,7 +129,6 @@ describe("useResources", () => {
       });
     };
 
-    UserModel.realCacheFields = UserModel.dependencies;
     document.body.appendChild(renderNode);
 
     requestSpy = vi.spyOn(Request, "default");
@@ -152,8 +151,6 @@ describe("useResources", () => {
   });
 
   afterEach(async () => {
-    UserModel.dependencies = UserModel.realCacheFields;
-
     Request.default.mockRestore();
     Model.prototype.fetch.mockRestore();
     Collection.prototype.fetch.mockRestore();
@@ -276,7 +273,7 @@ describe("useResources", () => {
   describe("updates a resource", () => {
     it("when its cache key changes with props", async () => {
       // decisions collection should update when passed `include_deleted`,
-      // since that exists on its cacheFields property
+      // since that exists on its dependencies property
       resources = renderUseResources();
 
       await waitsFor(() => requestSpy.mock.calls.length);
@@ -515,6 +512,8 @@ describe("useResources", () => {
       });
 
       it("can invoke a dependencies function entry", () => {
+        const realDependencies = UserModel.dependencies;
+
         UserModel.dependencies = [
           "userId",
           ({ fraudLevel, lastName }) => ({
@@ -533,6 +532,8 @@ describe("useResources", () => {
             },
           })
         ).toEqual("userfraudLevel=highgrant_lastName=grant_userId=noah");
+
+        UserModel.dependencies = realDependencies;
       });
     });
   });
@@ -812,10 +813,10 @@ describe("useResources", () => {
     });
 
     it("reverts to pending if removed dependent prop does not affect cache key", async () => {
-      var originalCacheFields = DecisionLogsCollection.cacheFields;
+      var originalDependencies = DecisionLogsCollection.dependencies;
 
       await unmountAndClearModelCache();
-      DecisionLogsCollection.cacheFields = [];
+      DecisionLogsCollection.dependencies = [];
 
       dataChild = findDataChild(renderUseResources({ serial: true }));
 
@@ -834,7 +835,7 @@ describe("useResources", () => {
       expect(isPending(dataChild.props.decisionLogsLoadingState)).toBe(true);
       expect(!!dataChild.props.decisionLogsCollection.isEmptyModel).toBe(false);
 
-      DecisionLogsCollection.cacheFields = originalCacheFields;
+      DecisionLogsCollection.dependencies = originalDependencies;
     });
   });
 


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
Removes deprecated `cacheFields` property
