### PR TITLE
change loading utils to be under Utils namespace

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,11 +4,6 @@ export { default as sync, ajax } from "./lib/sync";
 export { default as prefetch } from "./lib/prefetch";
 export { default as request } from "./lib/request";
 export { default as ModelCache } from "./lib/model-cache";
-export {
-  hasErrored as haveAnyErrored,
-  hasLoaded as haveAllLoaded,
-  isLoading as areAnyLoading,
-  isPending as areAnyPending,
-} from "./lib/utils";
+export * as Utils from "./lib/utils";
 export { ModelMap, ResourceKeys, ResourcesConfig } from "./lib/config";
 export { useResources, withResources } from "./lib/resourcerer";

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,4 +1,4 @@
-import { areAnyLoading, areAnyPending, haveAllLoaded, haveAnyErrored } from "../index";
+import { Utils } from "../index";
 import {
   camelize,
   hasErrored,
@@ -22,23 +22,23 @@ describe("Utils", () => {
       expect(hasErrored(["error", "loading"])).toBe(true);
       expect(hasErrored("error")).toBe(true);
       expect(hasErrored({ myLoadingState: "error" })).toBe(true);
-      expect(haveAnyErrored(["error", "loading"])).toBe(true);
-      expect(haveAnyErrored("error")).toBe(true);
-      expect(haveAnyErrored({ myLoadingState: "error" })).toBe(true);
+      expect(Utils.hasErrored(["error", "loading"])).toBe(true);
+      expect(Utils.hasErrored("error")).toBe(true);
+      expect(Utils.hasErrored({ myLoadingState: "error" })).toBe(true);
     });
 
     it("returns false if no loading states have errored", () => {
       expect(hasErrored(["loaded", "loading"])).toBe(false);
       expect(hasErrored("loaded")).toBe(false);
       expect(hasErrored({ myLoadingState: "loaded" })).toBe(false);
-      expect(haveAnyErrored(["loaded", "loading"])).toBe(false);
-      expect(haveAnyErrored("loaded")).toBe(false);
-      expect(haveAnyErrored({ myLoadingState: "loaded" })).toBe(false);
+      expect(Utils.hasErrored(["loaded", "loading"])).toBe(false);
+      expect(Utils.hasErrored("loaded")).toBe(false);
+      expect(Utils.hasErrored({ myLoadingState: "loaded" })).toBe(false);
     });
 
     it("returns false if an undefined loading state is passed", () => {
       expect(hasErrored(undefined)).toBe(false);
-      expect(haveAnyErrored(undefined)).toBe(false);
+      expect(Utils.hasErrored(undefined)).toBe(false);
     });
   });
 
@@ -47,23 +47,23 @@ describe("Utils", () => {
       expect(isLoading(["error", "loading"])).toBe(true);
       expect(isLoading("loading")).toBe(true);
       expect(isLoading({ myLoadingState: "loading" })).toBe(true);
-      expect(areAnyLoading(["error", "loading"])).toBe(true);
-      expect(areAnyLoading("loading")).toBe(true);
-      expect(areAnyLoading({ myLoadingState: "loading" })).toBe(true);
+      expect(Utils.isLoading(["error", "loading"])).toBe(true);
+      expect(Utils.isLoading("loading")).toBe(true);
+      expect(Utils.isLoading({ myLoadingState: "loading" })).toBe(true);
     });
 
     it("returns false if no loading states are loading", () => {
       expect(isLoading(["loaded", "loaded"])).toBe(false);
       expect(isLoading("loaded")).toBe(false);
       expect(isLoading({ myLoadingState: "loaded" })).toBe(false);
-      expect(areAnyLoading(["loaded", "loaded"])).toBe(false);
-      expect(areAnyLoading("loaded")).toBe(false);
-      expect(areAnyLoading({ myLoadingState: "loaded" })).toBe(false);
+      expect(Utils.isLoading(["loaded", "loaded"])).toBe(false);
+      expect(Utils.isLoading("loaded")).toBe(false);
+      expect(Utils.isLoading({ myLoadingState: "loaded" })).toBe(false);
     });
 
     it("returns false if an undefined loading state is passed", () => {
       expect(isLoading(undefined)).toBe(false);
-      expect(areAnyLoading(undefined)).toBe(false);
+      expect(Utils.isLoading(undefined)).toBe(false);
     });
   });
 
@@ -72,9 +72,9 @@ describe("Utils", () => {
       expect(hasLoaded(["loaded", "loaded"])).toBe(true);
       expect(hasLoaded("loaded")).toBe(true);
       expect(hasLoaded({ myLoadingState: "loaded" })).toBe(true);
-      expect(haveAllLoaded(["loaded", "loaded"])).toBe(true);
-      expect(haveAllLoaded("loaded")).toBe(true);
-      expect(haveAllLoaded({ myLoadingState: "loaded" })).toBe(true);
+      expect(Utils.hasLoaded(["loaded", "loaded"])).toBe(true);
+      expect(Utils.hasLoaded("loaded")).toBe(true);
+      expect(Utils.hasLoaded({ myLoadingState: "loaded" })).toBe(true);
     });
 
     it("returns false if any state has not loaded", () => {
@@ -82,15 +82,15 @@ describe("Utils", () => {
       expect(hasLoaded(["loaded", "loading"])).toBe(false);
       expect(hasLoaded("loading")).toBe(false);
       expect(hasLoaded({ myLoadingState: "loading" })).toBe(false);
-      expect(haveAllLoaded(["error", "loaded"])).toBe(false);
-      expect(haveAllLoaded(["loaded", "loading"])).toBe(false);
-      expect(haveAllLoaded("loading")).toBe(false);
-      expect(haveAllLoaded({ myLoadingState: "loading" })).toBe(false);
+      expect(Utils.hasLoaded(["error", "loaded"])).toBe(false);
+      expect(Utils.hasLoaded(["loaded", "loading"])).toBe(false);
+      expect(Utils.hasLoaded("loading")).toBe(false);
+      expect(Utils.hasLoaded({ myLoadingState: "loading" })).toBe(false);
     });
 
     it("returns false if an undefined loading state is passed", () => {
       expect(hasLoaded(undefined)).toBe(false);
-      expect(haveAllLoaded(undefined)).toBe(false);
+      expect(Utils.hasLoaded(undefined)).toBe(false);
     });
   });
 
@@ -99,23 +99,23 @@ describe("Utils", () => {
       expect(isPending(["pending", "loading"])).toBe(true);
       expect(isPending("pending")).toBe(true);
       expect(isPending({ myLoadingState: "pending" })).toBe(true);
-      expect(areAnyPending(["pending", "loading"])).toBe(true);
-      expect(areAnyPending("pending")).toBe(true);
-      expect(areAnyPending({ myLoadingState: "pending" })).toBe(true);
+      expect(Utils.isPending(["pending", "loading"])).toBe(true);
+      expect(Utils.isPending("pending")).toBe(true);
+      expect(Utils.isPending({ myLoadingState: "pending" })).toBe(true);
     });
 
     it("returns false if no loading states are pending", () => {
       expect(isPending(["loaded", "loading"])).toBe(false);
       expect(isPending("loaded")).toBe(false);
       expect(isPending({ myLoadingState: "loaded" })).toBe(false);
-      expect(areAnyPending(["loaded", "loading"])).toBe(false);
-      expect(areAnyPending("loaded")).toBe(false);
-      expect(areAnyPending({ myLoadingState: "loaded" })).toBe(false);
+      expect(Utils.isPending(["loaded", "loading"])).toBe(false);
+      expect(Utils.isPending("loaded")).toBe(false);
+      expect(Utils.isPending({ myLoadingState: "loaded" })).toBe(false);
     });
 
     it("returns false if an undefined loading state is passed", () => {
       expect(isPending(undefined)).toBe(false);
-      expect(areAnyPending(undefined)).toBe(false);
+      expect(Utils.isPending(undefined)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

removes `areAnyLoading`, `haveAllLoaded` etc, in favor of `Utils.isLoading`, `Utils.hasLoaded`, etc.

```js
// now exports a Utils namespace for these helpers
import {Utils} from "resourcerer";
```
