### PR TITLE
Path object

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -7,6 +7,7 @@ interface RequestOptions extends Pick<SyncOptions, "params"> {
   data?: any;
   component?: NonNullable<unknown>;
   options?: Record<string, any>;
+  path?: Record<string, any>;
   fetch?: boolean;
   force?: boolean;
   lazy?: boolean;
@@ -81,7 +82,8 @@ export default (
   if (!loadingCache[key]) {
     _promise = new Promise((resolve, reject) => {
       if (!cachedModel || cachedModel.lazy || options.force) {
-        const model = cachedModel || new Model(options.data, options.options);
+        const model =
+          cachedModel || new Model(options.data, { ...options.options, ...options.path });
 
         if (options.fetch && !options.lazy) {
           addToLoadingCache = true;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -26,6 +26,7 @@ export type ResourceConfigObj = {
   modelKey?: ResourceKeysType;
   noncritical?: boolean;
   options?: { [key: string]: any };
+  path?: { [key: string]: any };
   params?: { [key: string]: any };
   prefetches?: { [key: string]: any }[];
   provides?: { [key: string]: (model: Model | Collection, props: Record<string, any>) => any };

--- a/test/prefetch.test.js
+++ b/test/prefetch.test.js
@@ -10,7 +10,7 @@ const renderNode = document.createElement("div");
 const getResources = (_, props) => ({
   user: {
     params: { home: props.home, source: props.source },
-    options: { userId: props.userId },
+    path: { userId: props.userId },
   },
   decisions: {},
 });
@@ -42,7 +42,7 @@ describe("prefetch", () => {
     expect(Request.default.mock.calls[0][0]).toEqual("usersource=hbase_userId=noah");
     expect(Request.default.mock.calls[0][1]).toEqual(UserModel);
     expect(Request.default.mock.calls[0][2]).toEqual({
-      options: { userId: "noah" },
+      path: { userId: "noah" },
       params: { home: "sf", source: "hbase" },
     });
 

--- a/test/resourcerer.test.jsx
+++ b/test/resourcerer.test.jsx
@@ -43,7 +43,7 @@ const getResources = (_, props) => ({
       ...(props.shouldError ? { shouldError: true } : {}),
       ...(props.delay ? { delay: props.delay } : {}),
     },
-    options: { userId: props.userId, fraudLevel: props.fraudLevel },
+    path: { userId: props.userId, fraudLevel: props.fraudLevel },
     ...(props.force ? { force: true } : {}),
   },
   ...(props.prefetch ?
@@ -64,7 +64,7 @@ const getResources = (_, props) => ({
           : { serialProp: transformSpy.mockReturnValue(42) },
       },
       decisionLogs: {
-        options: { logs: props.serialProp },
+        path: { logs: props.serialProp },
         dependsOn: ["serialProp"],
       },
     }
@@ -84,7 +84,7 @@ const getResources = (_, props) => ({
  * Note we need to ensure the component has loaded in most cases before we
  * unmount so that we don't empty the cache before the models get loaded.
  */
-describe("useResources", () => {
+describe("resourcerer", () => {
   var originalPerf = window.performance,
     dataChild,
     resources,
@@ -501,12 +501,12 @@ describe("useResources", () => {
         }
       );
 
-      it("prioritizes dependencies in 'options' or 'data' config properties", () => {
+      it("prioritizes dependencies in 'path' or 'data' config properties", () => {
         expect(
           getCacheKey({
             params: { fraudLevel: "miniscule" },
             modelKey: "user",
-            options: { userId: "theboogieman" },
+            path: { userId: "theboogieman" },
           })
         ).toEqual("userfraudLevel=miniscule_userId=theboogieman");
       });
@@ -721,7 +721,7 @@ describe("useResources", () => {
         expect(ResourcesConfig.track).toHaveBeenCalledWith("API Fetch", {
           Resource: "decisions",
           params: undefined,
-          options: undefined,
+          path: undefined,
           duration: 5,
         });
 
@@ -750,7 +750,7 @@ describe("useResources", () => {
         expect(ResourcesConfig.track).toHaveBeenCalledWith("API Fetch", {
           Resource: "decisions",
           params: { include_deleted: true },
-          options: undefined,
+          path: undefined,
           duration: 5,
         });
 


### PR DESCRIPTION
## Description of Proposed Changes:  
  -  Removes the `options` property in the ResourceConfigObject for a `path` object. Functionally equivalent, but semantically this property is used to pass params to the `url` function for path params.

