### PR TITLE
invalidate

### DIFF
--- a/lib/model-cache.ts
+++ b/lib/model-cache.ts
@@ -103,6 +103,18 @@ export default {
    */
   remove(cacheKey: string) {
     clearModel(cacheKey);
+    componentManifest.delete(cacheKey);
+  },
+
+  /**
+   * A shortcut to remove all models of a given modelKey.
+   */
+  removeAllWithModel(modelKey: string) {
+    for (const key of modelCache.keys()) {
+      if (key === modelKey || key.startsWith(`${modelKey}~`)) {
+        this.remove(key);
+      }
+    }
   },
 
   // internal only

--- a/lib/resourcerer.ts
+++ b/lib/resourcerer.ts
@@ -386,6 +386,11 @@ export const useResources = (getResources: ExecutorFunction, _props: Record<stri
       });
     },
 
+    /**
+     * For each modelKey, find all entries in the cache and remove them.
+     */
+    invalidate: (keys: ResourceKeys[]) => keys.forEach((key) => ModelCache.removeAllWithModel(key)),
+
     setResourceState,
 
     // here we include our model loading states, useful for noncritical resources

--- a/test/model-cache.test.js
+++ b/test/model-cache.test.js
@@ -184,4 +184,25 @@ describe("ModelCache", () => {
     // now immediately gone
     expect(ModelCache.get("foo")).not.toBeDefined();
   });
+
+  it("when calling 'removeAllWithModel' removes all models of a specific key", () => {
+    const cacheKeys = [
+      "user~userId=zorah",
+      "user~source=hbase_userId=noah",
+      "user",
+      "users",
+      "users~key=value",
+      "decisions",
+    ];
+
+    cacheKeys.forEach((key) => ModelCache.put(key, {}, {}));
+
+    ModelCache.removeAllWithModel("user");
+    expect(ModelCache.get("user")).not.toBeDefined();
+    expect(ModelCache.get("user~userId=zorah")).not.toBeDefined();
+    expect(ModelCache.get("user~source=hbase_userId=noah")).not.toBeDefined();
+    expect(ModelCache.get("users")).toBeDefined();
+    expect(ModelCache.get("users~key=value")).toBeDefined();
+    expect(ModelCache.get("decisions")).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Description of Proposed Changes:  
  -  Adds an `invalidate` function from `useResources` that will remove all models of a given modelKey from the cache.
