### PR TITLE
refetch fn takes a list of keys, not a fn

### DIFF
--- a/lib/resourcerer.ts
+++ b/lib/resourcerer.ts
@@ -369,9 +369,9 @@ export const useResources = (getResources: ExecutorFunction, _props: Record<stri
     ...props[ResourcesConfig.queryParamsPropName],
     ...resourceState,
 
-    refetch: (fn: () => ResourceKeys[]) => {
+    refetch: (keys: ResourceKeys[]) => {
       ReactDOM.unstable_batchedUpdates(() => {
-        fn().forEach((name) => {
+        keys.forEach((name) => {
           const model = getModelFromCache(findConfig([name, {}], getResources, props));
 
           /**

--- a/test/resourcerer.test.jsx
+++ b/test/resourcerer.test.jsx
@@ -1086,8 +1086,8 @@ describe("resourcerer", () => {
     await waitsFor(() => dataChild.props.hasLoaded);
 
     expect(requestSpy.mock.calls.length).toEqual(3);
-    dataChild.props.refetch(() => ["decisions", "user"]);
-    dataChild.props.refetch(() => ["decisions", "user"]);
+    dataChild.props.refetch(["decisions", "user"]);
+    dataChild.props.refetch(["decisions", "user"]);
 
     await waitsFor(() => !dataChild.props.hasLoaded);
 
@@ -1131,7 +1131,7 @@ describe("resourcerer", () => {
     await waitsFor(() => dataChild.props.hasLoaded);
 
     expect(secondChild.props.hasLoaded).toBe(true);
-    dataChild.props.refetch(() => ["decisions"]);
+    dataChild.props.refetch(["decisions"]);
 
     await waitsFor(() => dataChild.props.isLoading);
     expect(secondChild.props.isLoading).toBe(true);


### PR DESCRIPTION
## Description of Proposed Changes:  
  -  `Refetch` just takes a list of resource keys instead of a function that returns a list of resource keys

