### PR TITLE
refetch and invalidate can take a single resource key instead of a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,23 @@
 
 `resourcerer` is a library for declaratively fetching and caching your application's data. Its powerful [`useResources`](#useresources) React hook or [`withResources`](#withresources) higher-order React component (HOC) allows you to easily construct a component's data flow, including:
 
-* serial requests
-* prioritized rendering for critical data (enabling less critical or slower requests to not block interactivity)
-* delayed requests
-* prefetching
-* ...and more
+- serial requests
+- prioritized rendering for critical data (enabling less critical or slower requests to not block interactivity)
+- delayed requests
+- prefetching
+- ...and more
 
 Additional features include:
 
-* fully declarative (no more writing any imperative Fetch API calls)
-* first-class loading and error state support
-* smart client-side caching
-* lazy fetching
-* refetching
-* forced cache invalidation
-* updating a component when a resource updates
-* zero dependencies
-* < 6kB!
+- fully declarative (no more writing any imperative Fetch API calls)
+- first-class loading and error state support
+- smart client-side caching
+- lazy fetching
+- refetching
+- forced cache invalidation
+- updating a component when a resource updates
+- zero dependencies
+- < 6kB!
 
 Getting started is easy:
 
@@ -28,11 +28,11 @@ Getting started is easy:
 
 ```js
 // js/models/todos-collection.js
-import {Collection} from 'resourcerer';
+import { Collection } from "resourcerer";
 
 export default class TodosCollection extends Collection {
   url() {
-    return '/todos';
+    return "/todos";
   }
 }
 ```
@@ -41,124 +41,129 @@ export default class TodosCollection extends Collection {
 
 ```js
 // js/core/resourcerer-config.js
-import {register} from 'resourcerer';
-import TodosCollection from 'js/models/todos-collection';
+import { register } from "resourcerer";
+import TodosCollection from "js/models/todos-collection";
 
 // choose any string as its key, which becomes its ResourceKey
-register({todos: TodosCollection});
+register({ todos: TodosCollection });
 ```
 
 ```js
 // in your top level js file
-import 'js/core/resourcerer-config';
+import "js/core/resourcerer-config";
 ```
 
 3. Use your preferred abstraction (`useResources` hook or `withResources` HOC) to request your models in any component:
 
-    1. ### useResources
-    
-        ```jsx
-        import {useResources} from 'resourcerer';
+   1. ### useResources
 
-        // tell resourcerer which resource you want to fetch in your component
-        const getResources = (props) => ({todos: {}});
-        
-        function MyComponent(props) {
-          const {
-            isLoading,
-            hasErrored,
-            hasLoaded,
-            todosCollection
-          } = useResources(getResources, props);
-          
+      ```jsx
+      import { useResources } from "resourcerer";
+
+      // tell resourcerer which resource you want to fetch in your component
+      const getResources = (props) => ({ todos: {} });
+
+      function MyComponent(props) {
+        const { isLoading, hasErrored, hasLoaded, todosCollection } = useResources(
+          getResources,
+          props
+        );
+
+        // when MyComponent is mounted, the todosCollection is fetched and available
+        // as `todosCollection`!
+        return (
+          <div className="MyComponent">
+            {isLoading ?
+              <Loader />
+            : null}
+
+            {hasErrored ?
+              <ErrorMessage />
+            : null}
+
+            {hasLoaded ?
+              <ul>
+                {todosCollection.toJSON().map(({ id, name }) => (
+                  <li key={id}>{name}</li>
+                ))}
+              </ul>
+            : null}
+          </div>
+        );
+      }
+      ```
+
+   1. ### withResources
+
+      ```jsx
+      import React from "react";
+      import { withResources } from "resourcerer";
+
+      // tell resourcerer which resource you want to fetch in your component
+      @withResources((props) => ({ todos: {} }))
+      class MyComponent extends React.Component {
+        render() {
           // when MyComponent is mounted, the todosCollection is fetched and available
-          // as `todosCollection`!
+          // as `this.props.todosCollection`!
           return (
-            <div className='MyComponent'>
-              {isLoading ? <Loader /> : null}
-        
-              {hasErrored ? <ErrorMessage /> : null}
-       
-              {hasLoaded ? (
+            <div className="MyComponent">
+              {this.props.isLoading ?
+                <Loader />
+              : null}
+
+              {this.props.hasErrored ?
+                <ErrorMessage />
+              : null}
+
+              {this.props.hasLoaded ?
                 <ul>
-                  {todosCollection.toJSON().map(({id, name}) => (
-                    <li key={id}>{name}</li>
+                  {this.props.todosCollection.map((todoModel) => (
+                    <li key={todoModel.id}>{todoModel.get("name")}</li>
                   ))}
                 </ul>
-              ) : null}
+              : null}
             </div>
           );
         }
-        ```
-    
-    1. ### withResources
-    
-        ```jsx
-        import React from 'react';
-        import {withResources} from 'resourcerer';
-
-        // tell resourcerer which resource you want to fetch in your component
-        @withResources((props) => ({todos: {}}))
-        class MyComponent extends React.Component {
-          render() {
-            // when MyComponent is mounted, the todosCollection is fetched and available
-            // as `this.props.todosCollection`!
-            return (
-              <div className='MyComponent'>
-                {this.props.isLoading ? <Loader /> : null}
-        
-                {this.props.hasErrored ? <ErrorMessage /> : null}
-        
-                {this.props.hasLoaded ? (
-                  <ul>
-                    {this.props.todosCollection.map((todoModel) => (
-                      <li key={todoModel.id}>{todoModel.get('name')}</li>
-                    ))}
-                  </ul>
-                ) : null}
-              </div>
-            );
-          }
-        }
-        ```
+      }
+      ```
 
 There's a lot there, so let's unpack that a bit. There's also a lot more that we can do there, so let's also get into that. But first, some logistics:
 
-# Contents  
+# Contents
 
 1. [Installation](#installation)
 1. [Nomenclature](#nomenclature)
 1. [Tutorial](#tutorial)
-    1. [Intro](#tutorial)
-    1. [Other Props Returned from the Hook/Passed from the HOC (Loading States)](#other-props-returned-from-the-hookpassed-from-the-hoc-loading-states)
-    1. [Requesting Prop-driven Data](#requesting-prop-driven-data)
-    1. [Changing Props](#changing-props)
-    1. [Common Resource Config Options](#common-resource-config-options)
-        1. [params](#params)
-        1. [options](#options)
-        1. [noncritical](#noncritical)
-        1. [force](#force)
-        1. [Custom Resource Names](#custom-resource-names)
-        1. [prefetches](#prefetches)
-        1. [data](#data)
-        1. [lazy](#lazy)
-        1. [minDuration](#minduration) 
-        1. [dependsOn](#dependson)
-        1. [provides](#provides)
-    1. [Data mutations](#data-mutations)
-    1. [Serial Requests](#serial-requests)
-    3. [Differences between useResources and withResources](#differences-between-useresources-and-withresources)
-    4. [Using resourcerer with TypeScript](docs/typescript.md)
-    4. [Caching Resources with ModelCache](#caching-resources-with-modelcache)
-    5. [Declarative Cache Keys](#declarative-cache-keys)
-    6. [Prefetch on Hover](#prefetch-on-hover)
-    7. [Refetching](#refetching)
-    8. [Cache Invalidation](#cache-invalidation)
-    9. [Tracking Request Times](#tracking-request-times)
+   1. [Intro](#tutorial)
+   1. [Other Props Returned from the Hook/Passed from the HOC (Loading States)](#other-props-returned-from-the-hookpassed-from-the-hoc-loading-states)
+   1. [Requesting Prop-driven Data](#requesting-prop-driven-data)
+   1. [Changing Props](#changing-props)
+   1. [Common Resource Config Options](#common-resource-config-options)
+      1. [params](#params)
+      1. [options](#options)
+      1. [noncritical](#noncritical)
+      1. [force](#force)
+      1. [Custom Resource Names](#custom-resource-names)
+      1. [prefetches](#prefetches)
+      1. [data](#data)
+      1. [lazy](#lazy)
+      1. [minDuration](#minduration)
+      1. [dependsOn](#dependson)
+      1. [provides](#provides)
+   1. [Data mutations](#data-mutations)
+   1. [Serial Requests](#serial-requests)
+   1. [Differences between useResources and withResources](#differences-between-useresources-and-withresources)
+   1. [Using resourcerer with TypeScript](docs/typescript.md)
+   1. [Caching Resources with ModelCache](#caching-resources-with-modelcache)
+   1. [Declarative Cache Keys](#declarative-cache-keys)
+   1. [Prefetch on Hover](#prefetch-on-hover)
+   1. [Refetching](#refetching)
+   1. [Cache Invalidation](#cache-invalidation)
+   1. [Tracking Request Times](#tracking-request-times)
 1. [Configuring resourcerer](#configuring-resourcerer)
 1. [FAQs](#faqs)
 1. [Migrating to v2.0](#migrating-to-v20)
-
 
 # Installation
 
@@ -172,47 +177,49 @@ If you are using TypeScript yourself, this won't be a problem. If you're not, an
 ```js
 // webpack.config.js or similar
 module: {
-  rules: [{
-    test: /\.jsx?$/,
-    exclude: /node_modules\/(?!(resourcerer))/,
-    use: {loader: 'babel-loader?cacheDirectory=true'}
-  }]
+  rules: [
+    {
+      test: /\.jsx?$/,
+      exclude: /node_modules\/(?!(resourcerer))/,
+      use: { loader: "babel-loader?cacheDirectory=true" },
+    },
+  ];
 }
 ```
 
 # Nomenclature
 
-1. **Props**. Going forward in this tutorial, we'll try to describe behavior of both the `useResources` hook and the `withResources` HOC at once; we'll also rotate between the two in examples. Note that if we talking about a passed prop of, for example `isLoading`, that that corresponds to an `isLoading` property returned from the hook and a `this.props.isLoading` prop passed down from the HOC. 
-  
+1. **Props**. Going forward in this tutorial, we'll try to describe behavior of both the `useResources` hook and the `withResources` HOC at once; we'll also rotate between the two in examples. Note that if we talking about a passed prop of, for example `isLoading`, that that corresponds to an `isLoading` property returned from the hook and a `this.props.isLoading` prop passed down from the HOC.
+
 1. **ResourceKeys**. These are the keys of the object passed to the `register` function in your top-level `resourcerer-config.js` file (discussed above in the introduction). The object is of type `Record<ResourceKeys, new () => Model | new () => Collection>`. These keys are passed to the executor functions and are used to tell the hook or HOC which resources to request.
 
 1. **Executor Function**. The executor function is a function that both the hook and HOC accept that declaratively describes which resources to request and with what config options. In these docs you'll often see it assigned to a variable called `getResources`. It accepts `props` as arguments and may look like, as we'll explore in an example later:
 
-    ```js
-    const getResources = (props) => ({user: {path: {userId: props.id}}});
-    ```
+   ```js
+   const getResources = (props) => ({ user: { path: { userId: props.id } } });
+   ```
 
-    or
+   or
 
-    ```js
-    const getResources = (props) => {
-      const now = Date.now();
-      
-      return {
-        userTodos: {
-          params: {
-            limit: 20,
-            end_time: now,
-            start_time: now - props.timeRange,
-            sort_field: props.sortField
-          }
-        }
-      };
-    };
-    ```
+   ```js
+   const getResources = (props) => {
+     const now = Date.now();
 
-    It returns an object whose keys represent the resources to fetch and whose values are **Resource Configuration Objects** that we'll discuss later (and is highlighted below).
-    
+     return {
+       userTodos: {
+         params: {
+           limit: 20,
+           end_time: now,
+           start_time: now - props.timeRange,
+           sort_field: props.sortField,
+         },
+       },
+     };
+   };
+   ```
+
+   It returns an object whose keys represent the resources to fetch and whose values are **Resource Configuration Objects** that we'll discuss later (and is highlighted below).
+
 1. **Resource Configuration Object**. In the object returned by our executor function, each entry has a key equal to one of the `ResourceKeys` and whose value we will refer to in this document as a Resource Configuration Object, or Resource Config for short. It holds the declarative instructions that `useResources` and `withResources` will use to request the resource.
 
 # Tutorial
@@ -221,11 +228,11 @@ Okay, back to the initial example. Let's take a look at our `useResources` usage
 
 ```js
 // `@withResources((props) => ({todos: {}}))`
-const getResources = (props) => ({todos: {}});
+const getResources = (props) => ({ todos: {} });
 
 export default function MyComponent(props) {
   const resources = useResources(getResources, props);
-  
+
   // ...
 }
 ```
@@ -235,36 +242,34 @@ takes a single argument: the current props, which are component props when you u
 
 ```js
 // js/core/resourcerer-config.js
-import {register} from 'resourcerer';
-import TodosCollection from 'js/models/todos-collection';
+import { register } from "resourcerer";
+import TodosCollection from "js/models/todos-collection";
 
 // after adding this key, `todos` can be used in our executor functions to reference the Todos resource.
 // The 'todos' string value will also be the default prefix for all todos-related return values.
 // That's why we have `props.todosCollection`!
-register({todos: TodosCollection});
+register({ todos: TodosCollection });
 ```
 
-(We can also pass custom prefixes for our prop names in a component, but [we'll get to that later](#custom-resource-names).)  
+(We can also pass custom prefixes for our prop names in a component, but [we'll get to that later](#custom-resource-names).)
 
 Back to the executor function. In the example above, you see it returns an object of `{todos: {}}`. In general, the object it should return is of type `{[key: ResourceKeys]: ResourceConfigObject}`, where `ResourceConfigObject` is a generic map of config options. It can contain as many keys as resources you would like the component to request. In our initial example, the Resource Config Object was empty. Further down, we'll go over the plethora of options and how to use them. For now, let's take a look at some of the resource-related props this simple configuration provides our component.
 
-
 ## Other Props Returned from the Hook/Passed from the HOC (Loading States)
 
-Of course, in our initial example, the `todosCollection` won’t be populated with data immediately since, after all, the resource has to be fetched from the API.  Some of the most **significant** and most common React UI states we utilize are whether a component’s critical resources have loaded entirely, whether any are still loading, or whether any have errored out. This is how we can appropriately cover our bases&mdash;i.e., we can ensure the component shows a loader while the resource is still in route, or if something goes wrong, we can ensure the component will still fail gracefully and not break the layout. To address these concerns, the `useResources` hook/`withResources` HOC gives you several loading state helper props. From our last example:
-
+Of course, in our initial example, the `todosCollection` won’t be populated with data immediately since, after all, the resource has to be fetched from the API. Some of the most **significant** and most common React UI states we utilize are whether a component’s critical resources have loaded entirely, whether any are still loading, or whether any have errored out. This is how we can appropriately cover our bases&mdash;i.e., we can ensure the component shows a loader while the resource is still in route, or if something goes wrong, we can ensure the component will still fail gracefully and not break the layout. To address these concerns, the `useResources` hook/`withResources` HOC gives you several loading state helper props. From our last example:
 
 - `todosLoadingState` (can be equal to any of the [LoadingStates constants](https://github.com/noahgrant/resourcerer/blob/06ed847a8d8d0daefd3ad1b7634d887767d338ac/lib/types.ts#L4). There will be one for each resource, and the property names will be equal to `${resourceKey}LoadingState`)
 - `hasLoaded` {boolean} - all critical resources have successfully completed and are ready to be used by the component
 - `isLoading` {boolean} - any of the critical resources are still in the process of being fetched
 - `hasErrored` {boolean} - any of the critical resource requests did not complete successfully
-  
+
 `isLoading` , `hasLoaded` , and `hasErrored` are not based on individual loading states, but are rather a collective loading state for the aforementioned-critical component resources. In the previous example, the todos resource is the only critical resource, so `isLoading` / `hasLoaded` / `hasErrored` are solely based on `todosLoadingState`. But we can also add a non-critical `users` resource, responsible, say, for only display users' names alongside their TODOs&mdash;a small piece of the overall component and not worth delaying render over. Here’s how we do that:
 
 ```js
 const getResources = (props) => ({
   todos: {},
-  users: {noncritical: true}
+  users: { noncritical: true },
 });
 
 function MyClassWithTodosAndAUsers(props) {
@@ -275,9 +280,9 @@ function MyClassWithTodosAndAUsers(props) {
 `MyClassWithTodosAndAUsers` will now receive the following loading-related props, assuming we've registered a `usersCollection` in our config file:
 
 - `todosLoadingState`
-- `usersLoadingState` 
+- `usersLoadingState`
 - `isLoading`
-- `hasLoaded` 
+- `hasLoaded`
 - `hasErrored`
 
 In this case, `isLoading` , et al, are only representative of `todosLoadingState` and completely irrespective of `usersLoadingState` . This allow us an incredible amount of flexibility for rendering a component as quickly as possible.
@@ -296,22 +301,22 @@ function MyClassWithTodosAndAUsers(props) {
     usersCollection,
     usersLoadingState
   } = useResources(getResources, props);
-  
+
   var getUserName = (userId) => {
     // usersCollection guaranteed to have returned here
     var user = usersCollection.find(({id}) => id === userId);
-            
+
     return (
       <span className='user-name'>
         {user && user.id || 'N/A'}
       </span>
     );
   };
-          
+
   return (
     <div className='MyClassWithTodosAndUsers'>
       {isLoading ? <Loader /> : null}
-          
+
       {hasLoaded ? (
         // at this point we are guaranteed all critical resources have returned.
         // before that, todosCollection is still a Collection instance that can be
@@ -330,7 +335,7 @@ function MyClassWithTodosAndAUsers(props) {
           )}
         </ul>
       ) : null}
-          
+
       {hasErrored ? <ErrorMessage /> : null}
     </div>
   );
@@ -346,20 +351,19 @@ And here's what it looks like when the stats endpoint returns:
 
 There’s one other loading prop offered from the hook/HOC: `hasInitiallyLoaded`. This can be useful for showing a different UI for components that have already fetched the resource. An example might be a component with filters: when a filter is changed after the initial resource is loaded (thus re-fetching the resource), we may want to show a loader with an overlay over the previous version of the component. See the [Advanced Topics docs](/docs/advanced_topics.md#loading-overlays) for more.
 
-
 ## Requesting Prop-driven Data
 
 Let's say we wanted to request not the entire users collection, but just a specific user. Here's our config:
 
 ```js
 // js/core/resourcerer-config.js
-import {register} from 'resourcerer';
-import TodosCollection from 'js/models/todos-collection';
-import UserModel from 'js/models/user-model';
+import { register } from "resourcerer";
+import TodosCollection from "js/models/todos-collection";
+import UserModel from "js/models/user-model";
 
 register({
   todos: TodosCollection,
-  user: UserModel
+  user: UserModel,
 });
 ```
 
@@ -367,16 +371,16 @@ And here's what our model might look like (NOTE: use a Model when you've got one
 
 ```js
 // js/models/user-model.js
-import {Model} from 'resourcerer';
+import { Model } from "resourcerer";
 
 export default class UserModel extends Model {
-  url({userId}) {
+  url({ userId }) {
     // `userId` is passed in here because we have
     // `path: {userId: props.id}` in the resource config object
     return `/users/${userId}`;
   }
-  
-  static dependencies = ['userId'];
+
+  static dependencies = ["userId"];
 }
 ```
 
@@ -389,12 +393,12 @@ The `dependencies` static property is important here, as we'll see in a second; 
 All three of these come from via the [Resource Configuration Object](#nomenclature) that is returned from our executor function; it might look like this:
 
 ```jsx
-const getResources = (props) => ({user: {path: {userId: props.id}}}) 
+const getResources = (props) => ({ user: { path: { userId: props.id } } });
 
 // hook
 function MyComponent(props) {
   const resources = useResources(getResources, props);
-  
+
   // ...
 }
 
@@ -402,23 +406,22 @@ function MyComponent(props) {
 @withResources(getResources)
 class MyComponentWithAUser extends React.Component {}
 ```
- 
+
 Assuming we have a `props.id` equal to `'noahgrant'`, this setup will put `MyComponentWithAUser` in a loading state until `/users/noahgrant` has returned.
-  
-### *...and here's the best part:*
-  
+
+### _...and here's the best part:_
+
 Let's say that `props.id` changes to a different user. `MyComponentWithAUser` will get put _back_ into a loading state while the new endpoint is fetched, _without us having to do anything!_ This works because our model has dictated that its models should be cached by a `userId` field, which is passed to it in the [`path` property](#path).
 
 ## Changing Props
+
 In general, there are two ways to change `props.id` as in the previous example:
 
 1. Change the url, which is the top-most state-carrying entity of any application. The url can be changed either by path parameter or query paramter, i.e. `example.com/users/noahgrant` -> `example.com/users/bobdonut`, or `example.com/users?id=noahgrant` -> `example.com/users?id=bobdonut`. In this case, each prop change is _indexable_, which is sometimes desirable, sometimes not.
 
 1. Change internal application state. For these cases, `useResources`/`withResources` make available another handy prop: `setResourceState`. `setResourceState` is a function that has the same method signature as the `useState` we all know and love. It sets internal hook/HOC state, which is then returned/passed down, respectively, overriding any initial prop, ie `setResourceState((state) => ({...state, id: 'bobdonut'}))`. This is _not_ indexable.
 
-    Note that `setResourceState` is very useful for the `withResources` HOC because it allows you to 'lift' state above the fetching component that otherwise would not be possible. For `useResources`, it is a nice-to-have in some cases, but because you can always define your own `useState` above the `useResources` invocation, you may find that you use it less often.
-
-
+   Note that `setResourceState` is very useful for the `withResources` HOC because it allows you to 'lift' state above the fetching component that otherwise would not be possible. For `useResources`, it is a nice-to-have in some cases, but because you can always define your own `useState` above the `useResources` invocation, you may find that you use it less often.
 
 ## Common Resource Config Options
 
@@ -427,27 +430,26 @@ In general, there are two ways to change `props.id` as in the previous example:
 The `params` option is passed directly to the [sync method](/docs/model.md#sync) and sent either as stringified query params (GET requests) or as a body (POST/PUT). Its properties are also referenced when generating a cache key if they are listed in a model's static `dependencies` property (See the [cache key section](#declarative-cache-keys) for more). Let's imagine that we have a lot of users and a lot of todos per user. So many that we only want to fetch the todos over a time range selected from a dropdown, sorted by a field also selected by a dropdown. These are query parameters we'd want to pass in our `params` property:
 
 ```js
-  @withResources((props) => {
-    const now = Date.now();
-      
-    return {
-      userTodos: {
-        params: {
-          limit: 20,
-          end_time: now,
-          start_time: now - props.timeRange,
-          sort_field: props.sortField
-        }
-      }
-    };
-  })
-  class UserTodos extends React.Component {}
+@withResources((props) => {
+  const now = Date.now();
+
+  return {
+    userTodos: {
+      params: {
+        limit: 20,
+        end_time: now,
+        start_time: now - props.timeRange,
+        sort_field: props.sortField,
+      },
+    },
+  };
+})
+class UserTodos extends React.Component {}
 ```
 
 Now, as the prop fields change, the params sent with the request changes as well (provided we set our `dependencies` property accordingly):
 
 `https://example.com/users/noahgrant/todos?limit=20&end_time=1494611831024&start_time=1492019831024&sort_field=importance`
-
 
 ### path
 
@@ -456,17 +458,17 @@ Now, as the prop fields change, the params sent with the request changes as well
 ```js
 const getResources = (props) => {
   const now = Date.now();
-      
+
   return {
     userTodos: {
       params: {
         limit: 20,
         end_time: now,
         start_time: now - props.timeRange,
-        sort_field: props.sortField
+        sort_field: props.sortField,
       },
-      path: {userId: props.userId}
-    }
+      path: { userId: props.userId },
+    },
   };
 };
 ```
@@ -476,16 +478,15 @@ Here, this UserTodosCollection instance will get a `userId` property passed to i
 ```js
 // js/models/user_todos_collection.js
 export class UserTodosCollection extends Collection {
-  url({userId}) {
+  url({ userId }) {
     // userId gets passed in for us to help construct our url
     return `/users/${userId}/todos`;
   }
-  
-  static dependencies = ['userId'];
-};
-```  
 
-  
+  static dependencies = ["userId"];
+}
+```
+
 ### noncritical
 
 As alluded to in the [Other Props](#other-props-returned-from-the-hookpassed-from-the-hoc-loading-states) section, not all resources used by the component are needed for rendering. By adding a `noncritical: true` option, we:
@@ -493,25 +494,22 @@ As alluded to in the [Other Props](#other-props-returned-from-the-hookpassed-fro
 - De-prioritize fetching the resource until after all critical resources have been fetched
 - Remove the resource from consideration within the component-wide loading states (`hasLoaded`, `isLoading`, `hasErrored`), giving us the ability to render without waiting on those resources
 - Can set our own UI logic around displaying noncritical data based on their individual loading states, ie `usersLoadingState`, which can be passed to the pure helper methods, `Utils.hasLoaded`, `Utils.hasErrored`, and `Utils.isLoading` from `resourcerer`.
-  
-  
 
 ### force
 
 Sometimes you want the latest of a resource, bypassing whatever model has already been cached in your application. To accomplish this, simply pass a `force: true` in a resource's config. The force-fetched response will replace any prior model in the cache.
 
 ```js
-  const getResources = (props) => ({latestStats: {force: true}});
+const getResources = (props) => ({ latestStats: { force: true } });
 
-  function MyComponentWithLatestStats(props) {
-    const {latestStatsModel} = useResources(getResources, props);
-  }
+function MyComponentWithLatestStats(props) {
+  const { latestStatsModel } = useResources(getResources, props);
+}
 ```
 
 The resource will only get force-requested when the component mounts; the `force` flag will get ignored on subsequent updates. If you need to refetch after mounting to get the latest resource, use [refetch](#refetching).
 
 This behavior is similar to the behavior you get with [cache invalidation](#cache-invalidation).
-
 
 ### Custom Resource Names
 
@@ -544,7 +542,7 @@ A great example of this is for pagination. Let's take our previous example and a
 const getResources = (props) => {
   const now = Date.now();
   const REQUESTS_PER_PAGE = 20;
-      
+
   return {
     userTodos: {
       params: {
@@ -552,15 +550,15 @@ const getResources = (props) => {
         limit: REQUESTS_PER_PAGE,
         end_time: now,
         start_time: now - props.timeRange,
-        sort_field: props.sortField
+        sort_field: props.sortField,
       },
-      path: {userId: props.userId},
+      path: { userId: props.userId },
       // this entry is how we expect the props to change. in this case, we want props.page to be
       // incremented. the resulting prefetched request will have a `from` value of 20, whereas the
       // original request will have a `from` value of 0. The `userTodosCollection` returned (hook) or
       // passed down as props (HOC) will be the latter.
-      prefetches: [{page: props.page + 1}]
-    }
+      prefetches: [{ page: props.page + 1 }],
+    },
   };
 };
 ```
@@ -574,17 +572,17 @@ If you're looking to optimistically prefetch resources when a user hovers, say, 
 Pass in a data hash to initialize a Model instance with data before initially fetching. This is passed directly to the [model](/docs/model.md#constructor) `constructor` method, and is typically much less useful than providing the properties directly to the [`params`](#params) property. One place it might be useful is to seed a model with an id you already have:
 
 ```js
-getResources = () => ({customer: {data: {id: props.customerId}}});
+getResources = () => ({ customer: { data: { id: props.customerId } } });
 
 function MyCustomerComponent(props) {
-  const {customerModel} = useResources(getResources, props);
+  const { customerModel } = useResources(getResources, props);
 
   // now you can reference the id directly on the model
-  console.log(customerModel.get('id')); // or the id shorthand, customerModel.id
+  console.log(customerModel.get("id")); // or the id shorthand, customerModel.id
 }
 ```
 
-You can also use `data` to take advantage of [re-caching](/docs/advanced_topics.md#recaching-newly-saved-models).  
+You can also use `data` to take advantage of [re-caching](/docs/advanced_topics.md#recaching-newly-saved-models).
 
 Like `params` and `path`, the `data` object will also be used in cache key generation if it has any fields specified in the model's static `dependencies` property (See the [cache key section](#declarative-cache-keys) for more).
 
@@ -624,7 +622,7 @@ function TodoSearchItem(props) {
   return (
     <tr>
       <td>{todoModel.get('name') || props.name}</td>
-      <td>{todoModel.get('updated_at') || props.updated_at}</td> 
+      <td>{todoModel.get('updated_at') || props.updated_at}</td>
     </tr>
   );
 ```
@@ -649,61 +647,61 @@ So far we've only discussed fetching data. But `resourcerer` also makes it very 
 
 1. [Model#save](/docs/model.md#save)
 
-    Use this to create a new resource object (POST) or update an existing one (PUT). Uses the return value of the [`isNew()`](/docs/model.md#isNew) method to determine which method to use. If updating, pass a `{patch: true}` option to use PATCH instead of PUT, which will also send over only the changed attributes instead of the entire resource.
+   Use this to create a new resource object (POST) or update an existing one (PUT). Uses the return value of the [`isNew()`](/docs/model.md#isNew) method to determine which method to use. If updating, pass a `{patch: true}` option to use PATCH instead of PUT, which will also send over only the changed attributes instead of the entire resource.
 
-    ```js
-    function MyComponent(props) {
-      const {myModel} = useResources(getResources, props),
-            onSave = () => myModel.save({foo: 'bar'})
-              .then([model]) => // ...)
-              .catch(() => alert('request failed'));
-        
-      return <button onClick={onSave}>Persist model</button>;
-    }
-    ```
+   ```js
+   function MyComponent(props) {
+     const {myModel} = useResources(getResources, props),
+           onSave = () => myModel.save({foo: 'bar'})
+             .then([model]) => // ...)
+             .catch(() => alert('request failed'));
+
+     return <button onClick={onSave}>Persist model</button>;
+   }
+   ```
 
 1. [Model#destroy](/docs/model.md#destroy)
 
-    Use this to make a DELETE request at a url with this model's id. Will also remove the model from any collection it is a part of.
+   Use this to make a DELETE request at a url with this model's id. Will also remove the model from any collection it is a part of.
 
-    ```js
-    myModel.destroy().catch(() => alert('Model could not be destroyed));
-    ```
+   ```js
+   myModel.destroy().catch(() => alert('Model could not be destroyed));
+   ```
 
 1. [Collection#create](/docs/collection.md#create)
 
-    If working with a collection instead of a model, `.create()` adds a new model to the collection and then persists it to the server (via `model.save()`). This is pretty convenient:
+   If working with a collection instead of a model, `.create()` adds a new model to the collection and then persists it to the server (via `model.save()`). This is pretty convenient:
 
-    ```js
-    function TodoDetails(props) {
-      const {hasLoaded, todosCollection} = useResources(getResources, props),
-            todoModel = todosCollection.get(props.id),
-      
-            onSaveTodo = {
-              // set some loading state...
-        
-              if (!props.id) {
-                // create new todo!
-                return todosCollection.create(attrs)
-                  .then(([model]) => // ...)
-                  .catch(() => alert('create failed'));
-                  .then(() => // remove loading state);
-              }
-        
-              // update existing
-              todoModel.save(attrs).then(([model]) => ...).catch(() => alert('update failed'));
-            };
-      
-       if (hasLoaded && props.id && !todoModel) {
-         return <p>Todo not found.</p>;
-       }
-  
-       return (
-         // ...
-         <button onClick={onSaveTodo}>Save</button>
-       );
-    }
-    ```
+   ```js
+   function TodoDetails(props) {
+     const {hasLoaded, todosCollection} = useResources(getResources, props),
+           todoModel = todosCollection.get(props.id),
+
+           onSaveTodo = {
+             // set some loading state...
+
+             if (!props.id) {
+               // create new todo!
+               return todosCollection.create(attrs)
+                 .then(([model]) => // ...)
+                 .catch(() => alert('create failed'));
+                 .then(() => // remove loading state);
+             }
+
+             // update existing
+             todoModel.save(attrs).then(([model]) => ...).catch(() => alert('update failed'));
+           };
+
+      if (hasLoaded && props.id && !todoModel) {
+        return <p>Todo not found.</p>;
+      }
+
+      return (
+        // ...
+        <button onClick={onSaveTodo}>Save</button>
+      );
+   }
+   ```
 
 Each one of these methods exhibit the following behaviors:
 
@@ -712,14 +710,15 @@ Each one of these methods exhibit the following behaviors:
 1. On error, they undo the changes that were done (and their registered components render again).
 
 **Note:**
+
 1. All calls resolve an array, which is a tuple of `[model, response]`. All reject with just the response.
 1. All write calls must have a `.catch` attached, even if the rejection is swallowed. Omitting one risks an uncaught Promise rejection exception if the request fails.
-  
+
 ## Serial Requests
 
 In most situations, all resource requests should be parallelized; but that’s not always possible. Every so often, there may be a situation where one request depends on the result of another. For these cases, we have the `dependsOn` resource config option and the `provides` resource config option. These are probably best explained by example, so here is a simplified instance from the [Sift](https://sift.com) Console, where we load a queue item that has info about a user, but we can't get further user information until we know what user id belongs to this queue item.
 
-```js
+````js
 @withResources((props) => ({
   user: {
     path: {userId: props.userId},
@@ -737,7 +736,7 @@ In this simplified example, only `props.itemId` is initially present at the url 
 
 So, in this case, the returned `queueItemModel` instance is passed as an argument, and we return a string that will be assigned to `props.userId` (or, more accurately, will be set as state via `setResourceState` as described in the previous section). At tthis point, `props.userId` exists, and the UserModel will be fetched. And we have serially requested our resources!
 
-One thing to note here is that while the `queueItem` resource is being fetched, the user resource is in a `PENDING` state, which is a special state that does not contribute to overall component `isLoading`/`hasErrored` states (though it will keep the component from being `hasLoaded`). At this point, the `QueueItemPage` in the example above is in a `LOADING` state (`isLoading === true`) because `QUEUE_ITEM` is loading. When it returns with the user id, the `user` resource is put into a `LOADING` state, and the component then remains `isLoading === true` until it returns, after which the component has successfully loaded. If the `queueItem` resource happened to error for some reason, the `user` resource would never get out of its `PENDING` state, and the component would then take on the `ERROR` state (`hasErrored === true`) of `queueItem`. For more on `PENDING`, see [Thoughts on the PENDING State](/docs/advanced_topics.md#thoughts-on-the-pending-resource) in the [Advanced Topics document](/docs/advanced_topics.md).  
+One thing to note here is that while the `queueItem` resource is being fetched, the user resource is in a `PENDING` state, which is a special state that does not contribute to overall component `isLoading`/`hasErrored` states (though it will keep the component from being `hasLoaded`). At this point, the `QueueItemPage` in the example above is in a `LOADING` state (`isLoading === true`) because `QUEUE_ITEM` is loading. When it returns with the user id, the `user` resource is put into a `LOADING` state, and the component then remains `isLoading === true` until it returns, after which the component has successfully loaded. If the `queueItem` resource happened to error for some reason, the `user` resource would never get out of its `PENDING` state, and the component would then take on the `ERROR` state (`hasErrored === true`) of `queueItem`. For more on `PENDING`, see [Thoughts on the PENDING State](/docs/advanced_topics.md#thoughts-on-the-pending-resource) in the [Advanced Topics document](/docs/advanced_topics.md).
 
 Finally, note that the `provides` function can return any number of fields we want to set as new props for other resources:
 
@@ -753,7 +752,7 @@ const getResources = (props) => ({
     provides: (queueItemModel) => ({userId: queueItemModel.get('userId'), activeState: queueItemModel.get('state')})
   }
 });
-  
+
 export default function QueueItemPage(props) {
   // activeState and userId are internal state within `useResources` and returned
   const {
@@ -763,7 +762,7 @@ export default function QueueItemPage(props) {
     queueItemModel
   } = useResources(getResources, props);
 }
-```
+````
 
 # Differences between useResources and withResources
 
@@ -773,32 +772,32 @@ The hook and HOC largely operate interchangeably, but do note a couple critical 
 
 1. The executor function for a hook can be inlined in your component, which puts component props in its closure scope. So be extra careful to avoid this anti-pattern:
 
-    ```js
-    function MyComponent({start_time, ...props}) {
-      const {todosCollection} = useResources((_props) => ({todos: {params: {start_time}}}), props);
-      
-      // ...
-    ```
-    
-    The subtle problem with the above is that the `start_time` executor function parameter is relying on a value in the function component closure instead of the `_props` parameter object; props passed to the executor function can be current or previous but are not the same as what is in the closure, which will always be current. This will lead to confusing bugs, so instead either read directly from the props parameter passed to the executor function:
-    
-    ```js
-    function MyComponent(props) {
-      const {todosCollection} = useResources(({start_time}) => ({todos: {params: {start_time}}}), props);
-      
-      // ...
-    ```
-    
-     or, even clearer, define your executor function outside of the component scope, as we've done throughout this tutorial (now you know why!):
-     
-     ```js
-     const getResources = ({start_time}) => ({todos: {params: {start_time}}});
-     
-     function MyComponent(props) {
-       const {todosCollection} = useResources(getResources, props);
-       
-       // ...
-     ```
+   ```js
+   function MyComponent({start_time, ...props}) {
+     const {todosCollection} = useResources((_props) => ({todos: {params: {start_time}}}), props);
+
+     // ...
+   ```
+
+   The subtle problem with the above is that the `start_time` executor function parameter is relying on a value in the function component closure instead of the `_props` parameter object; props passed to the executor function can be current or previous but are not the same as what is in the closure, which will always be current. This will lead to confusing bugs, so instead either read directly from the props parameter passed to the executor function:
+
+   ```js
+   function MyComponent(props) {
+     const {todosCollection} = useResources(({start_time}) => ({todos: {params: {start_time}}}), props);
+
+     // ...
+   ```
+
+   or, even clearer, define your executor function outside of the component scope, as we've done throughout this tutorial (now you know why!):
+
+   ```js
+   const getResources = ({start_time}) => ({todos: {params: {start_time}}});
+
+   function MyComponent(props) {
+     const {todosCollection} = useResources(getResources, props);
+
+     // ...
+   ```
 
 ## Caching Resources with ModelCache
 
@@ -821,17 +820,17 @@ Let's take a look at the `userTodos` resource from above, where we want to reque
 ```js
 const getResources = (props) => {
   const now = Date.now();
-      
+
   return {
     userTodos: {
       params: {
         limit: props.limit,
         end_time: now,
         start_time: now - props.timeRange,
-        sort_field: props.sortField
+        sort_field: props.sortField,
       },
-      path: {userId: props.userId}
-    }
+      path: { userId: props.userId },
+    },
   };
 };
 ```
@@ -840,18 +839,18 @@ And our corresponding model definition might look like this:
 
 ```js
 export class UserTodosCollection extends Collection {
-  url({userId}) {
+  url({ userId }) {
     return `/users/${userId}/todos`;
   }
   // ...
-  
+
   static dependencies = [
-    'limit',
-    'userId',
-    'sort_field',
-     ({end_millis, start_millis}) => ({range: end_millis - start_millis})
+    "limit",
+    "userId",
+    "sort_field",
+    ({ end_millis, start_millis }) => ({ range: end_millis - start_millis }),
   ];
-};
+}
 ```
 
 We can see that `limit` and `sort_field` as specified in `dependencies` are taken straight from the `params` object that `resourcerer` transforms into url query parameters. `userId` is part of the `/users/{userId}/todos` path, so it can't be part of the `params` object, which is why it gets passed in the `path` object instead.
@@ -864,35 +863,36 @@ The generated cache key would be something like `userTodos~limit=50_$range=86400
 - the `limit` and `sort_field` values are taken from the `params` hash
 - the `range` value is taken from a function that takes `start_millis`/`end_millis` from the `params` hash into account.
 
-
 ## Prefetch on Hover
 
 You can use `resourcerer`'s executor function to optimistically prefetch resources when a user hovers over an element. For example, if a user hovers over a link to their TODOS page, you may want to get a head start on fetching their `todos` resource so that perceived loading time goes down or gets eliminated entirely. We can do this with the top-level `prefetch` function:
 
 ```jsx
-import {prefetch} from 'resourcerer';
+import { prefetch } from "resourcerer";
 
 // here's our executor function just as we pass to useResources or withResources
 const getTodos = (props) => {
   const now = Date.now();
-      
+
   return {
     userTodos: {
       params: {
         limit: props.limit,
         end_time: now,
         start_time: now - props.timeRange,
-        sort_field: props.sortField
+        sort_field: props.sortField,
       },
-      path: {userId: props.userId}
-    }
+      path: { userId: props.userId },
+    },
   };
 };
 
 // in your component, call the prefetch method with the executor and an object that matches
 // what you expect the props to look like when the resources are requested without prefetch.
 // attach the result to an `onMouseEnter` prop
-<a href='/todos' onMouseEnter={prefetch(getTodos, expectedProps)}>TODOS</a>
+<a href="/todos" onMouseEnter={prefetch(getTodos, expectedProps)}>
+  TODOS
+</a>;
 ```
 
 Note, as mentioned in the comment above, that `expectedProps` should take the form of props expected when the resource is actually needed. For example, maybe we're viewing a list of users, and so there is no `props.userId` in the component that uses `prefetch`. But for the user in the list with id `'noahgrant'`, we would pass it an `expectedProps` that includes `{userId: 'noahgrant'}` because we know that when we click on the link and navigate to that url, `props.userId` should be equal to `'noahgrant'`.
@@ -904,49 +904,50 @@ Note, as mentioned in the comment above, that `expectedProps` should take the fo
 1. A request timed out and you want to give the user the option of retrying.
 2. You have made a change to one resource that may render an auxiliary resource stale, and you want to bring the auxiliary resource up-to-date.
 
-The function takes a list of `ResourceKeys`. Each entry will get refetched.
+The function takes a single or a list of `ResourceKeys`. Each entry will get refetched.
 
 ```js
 function MyComponent(props) {
   const {todosCollection, refetch} = useResources(({start_time}) => ({todos: {params: {start_time}}}), props);
-      
+
   // ...
-  
-  return <Button onClick={() => refetch(["todos"])}>Refetch me</Button>;
+
+  return <Button onClick={() => refetch("todos")}>Refetch me</Button>;
 ```
 
 **NOTE:**
-* The list returned by the function should only include keys that are currently returned by the executor function. In the example above, returning `userTodos` would not fetch anything because it is not part of the current executor function. To conditionally fetch another resource, add it to the executor function with [dependsOn](#serial-requests).
-* The resource that will be refetched is the version returned by the executor function with the current props. To fetch a different version, use the standard props flow instead of refetching.
+
+- The list returned by the function should only include keys that are currently returned by the executor function. In the example above, returning `userTodos` would not fetch anything because it is not part of the current executor function. To conditionally fetch another resource, add it to the executor function with [dependsOn](#serial-requests).
+- The resource that will be refetched is the version returned by the executor function with the current props. To fetch a different version, use the standard props flow instead of refetching.
 
 ## Cache Invalidation
 
-In some cases you may want to imperatively remove a resource from the cache. For example, you may make a change to a related resource that renders a resource invalid. For those cases, `useResources` returns an `invalidate` function that takes a list of `ResourceKeys`:
+In some cases you may want to imperatively remove a resource from the cache. For example, you may make a change to a related resource that renders a resource invalid. For those cases, `useResources` returns an `invalidate` function that takes a single or a list of `ResourceKeys`:
 
 ```js
 function MyComponent(props) {
   const {todosCollection, invalidate} = useResources(({start_time}) => ({todos: {params: {start_time}}}), props);
-      
+
   // ...
-  
+
   return <Button onClick={() => invalidate(["todos"])}>Invalidate me</Button>;
 ```
 
-* Unlike [`refetching`](#refetching), the ResourceKeys passed to `invalidate` do not need to be from those returned by the executor function. They can any resource key.
+- Unlike [`refetching`](#refetching), the ResourceKeys passed to `invalidate` do not need to be from those returned by the executor function. They can any resource key.
 
 ## Tracking Request Times
 
 If you have a metrics aggregator and want to track API request times, you can do this by setting a `measure` static property on your model or collection. `measure` can either be a boolean or a function that returns a boolean. The function takes the resource config object as a parameter:
 
 ```js
-import {Model} from 'resourcerer';
+import { Model } from "resourcerer";
 
 class MyMeasuredModel extends Model {
   // either a boolean, which will track every request of this model instance
   static measure = true;
 
   // or a function that returns a boolean, which will track instance requests based on a condition
-  static measure = ({data={}}) => data.id === 'noahgrant';
+  static measure = ({ data = {} }) => data.id === "noahgrant";
 }
 ```
 
@@ -957,83 +958,80 @@ When the static `measure` property is/returns true, `resourcerer` will record th
 The same config file used to `register` your models also allows you to set custom configuration properties for your own application:
 
 ```js
-import {ResourcesConfig} from 'resourcerer';
+import { ResourcesConfig } from "resourcerer";
 
 ResourcesConfig.set(configObj);
 ```
 
 `ResourcesConfig.set` accepts an object with any of the following properties:
 
-* `cacheGracePeriod` (number in ms): the length of time a resource will be kept in the cache after being scheduled for removal (see the [caching section](#caching-resources-with-modelcache) for more). **Default:** 120000 (2 minutes). Note that each model class can provide its own timeout override.
+- `cacheGracePeriod` (number in ms): the length of time a resource will be kept in the cache after being scheduled for removal (see the [caching section](#caching-resources-with-modelcache) for more). **Default:** 120000 (2 minutes). Note that each model class can provide its own timeout override.
 
-* `errorBoundaryChild` (JSX/React.Element): the element or component that should be rendered in the ErrorBoundary included in every `withResources` wrapping. By default, a caught error renders this child:
+- `errorBoundaryChild` (JSX/React.Element): the element or component that should be rendered in the ErrorBoundary included in every `withResources` wrapping. By default, a caught error renders this child:
 
-    ```jsx
-    <div className='caught-error'>
-      <p>An error occurred.</p>
-    </div>
-    ```
+  ```jsx
+  <div className="caught-error">
+    <p>An error occurred.</p>
+  </div>
+  ```
 
-* `log` (function): method invoked when an error is caught by the ErrorBoundary. Takes the caught error as an argument. Use this hook to send caught errors to your error monitoring system. **Default:** noop.
+- `log` (function): method invoked when an error is caught by the ErrorBoundary. Takes the caught error as an argument. Use this hook to send caught errors to your error monitoring system. **Default:** noop.
 
-* `prefilter` (function): this function takes in the options object passed to the request and should return any new options you want to add. this is a great place to add custom request headers (like auth headers) or do custom error response handling. For example:
+- `prefilter` (function): this function takes in the options object passed to the request and should return any new options you want to add. this is a great place to add custom request headers (like auth headers) or do custom error response handling. For example:
 
-    ```js
-    prefilter: (options) => ({
-      error: (response) => {
-        if (response.status === 401) {
-          // refresh auth token logic
-        } else if (response.status === 429) {
-          // do some rate-limiting retry logic
-        }
-
-        // catch callbacks still get called after this, so always default to rejecting
-        return Promise.reject(response);
-      },
-      headers: {
-        ...options.headers,
-        Authorization: `Bearer ${localStorage.getItem('super-secret-auth-token')}`
+  ```js
+  prefilter: (options) => ({
+    error: (response) => {
+      if (response.status === 401) {
+        // refresh auth token logic
+      } else if (response.status === 429) {
+        // do some rate-limiting retry logic
       }
-    })
-    ```
 
-    **Default:** the identity function.
+      // catch callbacks still get called after this, so always default to rejecting
+      return Promise.reject(response);
+    },
+    headers: {
+      ...options.headers,
+      Authorization: `Bearer ${localStorage.getItem("super-secret-auth-token")}`,
+    },
+  });
+  ```
 
-* `stringify` (function): Use this to pass in a custom or more powerful way to stringify your GET parameters. The default is to use [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams), but that won't url-encode nested objects or arrays. Override this method if you need support for that, ie:
+  **Default:** the identity function.
 
-    ```js
-    import {stringify} from 'qs';
+- `stringify` (function): Use this to pass in a custom or more powerful way to stringify your GET parameters. The default is to use [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams), but that won't url-encode nested objects or arrays. Override this method if you need support for that, ie:
 
-    ResourcesConfig.set({
-      stringify(params, options) {
-        // params is the params object to be stringified into query parameters
-        // options is the request options object
-        return stringify(params);
-      }
-    });
-    ```
+  ```js
+  import { stringify } from "qs";
 
+  ResourcesConfig.set({
+    stringify(params, options) {
+      // params is the params object to be stringified into query parameters
+      // options is the request options object
+      return stringify(params);
+    },
+  });
+  ```
 
-* `track` (function): method invoked when [a `measure` property is added to a Model or Collection](#tracking-request-times). Use this hook to send the measured data to your application analytics tracker. **Default:** noop. The method is invoked with two arguments:
+- `track` (function): method invoked when [a `measure` property is added to a Model or Collection](#tracking-request-times). Use this hook to send the measured data to your application analytics tracker. **Default:** noop. The method is invoked with two arguments:
 
-    * the event string, `'API Fetch'`
-    * event data object with the following properties:
-        * Resource (string): the name of the resource (taken from the entry in `ResourceKeys`)
-        * params (object): params object supplied via the resource's config
-        * options (object): options object supplied via the resource's config
-        * duration (number): time in milliseconds between request and response
-
-
+  - the event string, `'API Fetch'`
+  - event data object with the following properties:
+    - Resource (string): the name of the resource (taken from the entry in `ResourceKeys`)
+    - params (object): params object supplied via the resource's config
+    - options (object): options object supplied via the resource's config
+    - duration (number): time in milliseconds between request and response
 
 # FAQs
 
-* Why?
+- Why?
 
-    Yeah...isn't [GraphQL](https://graphql.org/) the thing to use now? Why bother with a library for REST APIs?
-    
-    GraphQL is awesome, but there are many reasons why you might not want to use it. Maybe you don't have the resources to ensure that all of your data can be accessed performantly; in that case, your single `/graphql` endpoint will only ever be as fast as your slowest data source. Maybe your existing REST API is working well and your eng org isn't going to prioritize any time to move away from it. Etc, etc, etc. `resourcerer` offers a way for your front-end team to quickly get up and running with declarative data fetching, request flows, and model caching.
+  Yeah...isn't [GraphQL](https://graphql.org/) the thing to use now? Why bother with a library for REST APIs?
 
-* How is this different from React Query?
+  GraphQL is awesome, but there are many reasons why you might not want to use it. Maybe you don't have the resources to ensure that all of your data can be accessed performantly; in that case, your single `/graphql` endpoint will only ever be as fast as your slowest data source. Maybe your existing REST API is working well and your eng org isn't going to prioritize any time to move away from it. Etc, etc, etc. `resourcerer` offers a way for your front-end team to quickly get up and running with declarative data fetching, request flows, and model caching.
+
+- How is this different from React Query?
 
   React Query is an awesome popular library that shares some of the same features as resourcerer. But because `resourcerer` is _explicitly_ for REST APIs and React Query is backend agnostic, we get to abstract out even more. For example, in React Query, you'll need to imperatively fetch your resource in each component:
 
@@ -1083,53 +1081,50 @@ ResourcesConfig.set(configObj);
   ```
 
   The other big difference you might note is the data object in the hook's response. With React Query, you get exactly the JSON returned by the server. With resourcerer, you get [Model](/docs/model.md) or [Collection](/docs/collection.md) instances, which are enriched data representations from which you can also perform write operations that will propagate throughout all other subscribed components&mdash;regardless of their location in your application. Need to update a model? Call [`model.set()`](/docs/model.md#set)&mdash;any other component that uses that model (or its collection) will automatically update. Need to persist to the server? Call [`model.save()`](/docs/model.md#save) or [`collection.add()`](/docs/collection.md#add). Need to remove the model? [`model.destroy()`](/docs/model.md#destroy). Ez-pz.
-  
-  
+
   Also note that the `todosCollection` in both components 1 and 2 in the last example are the same objects.
 
+- Does `resourcerer` support SSR?
 
-* Does `resourcerer` support SSR?  
-  
-    There is no official documentation for its use in server-side rendering at this point. However, because passing models as props directly to a component [bypasses fetching](/docs/testing_components.md#testing-components-that-use-resourcerer), it is likely that `resourcerer` can work nicely with an SSR setup that:  
-    
-    1. passes instantiated models directly through the app before calling `renderToString`  
-    2. provides those models within a top-level `<script>` element that adds them directly to the [ModelCache](#caching-resources-with-modelcache).
+  There is no official documentation for its use in server-side rendering at this point. However, because passing models as props directly to a component [bypasses fetching](/docs/testing_components.md#testing-components-that-use-resourcerer), it is likely that `resourcerer` can work nicely with an SSR setup that:
 
+  1. passes instantiated models directly through the app before calling `renderToString`
+  2. provides those models within a top-level `<script>` element that adds them directly to the [ModelCache](#caching-resources-with-modelcache).
 
-* Can `resourcerer` do anything other than `GET` requests?
+- Can `resourcerer` do anything other than `GET` requests?
 
-    `resourcerer` only handles resource _fetching_ (i.e. calling [Model.prototype.fetch](/docs/model.md#fetch)). Note that this is not the same as only making `GET` requests; pass in a `method: 'POST'` property in a resource's config to turn the `params` property into a POST body, for example, when making a search request.
-    
-    For write operations, use Models' [`save`](/docs/model.md#save) and [`destroy`](/docs/model.md#destroy) methods directly:
-    
-    ```js
-    onClickSaveButton() {
-      this.setState({isSaving: true});
-  
-      // any other mounted component in the application that uses this resource
-      // will get re-rendered with the updated name as soon as this is called
-      this.props.userTodoModel.save({name: 'Giving This Todo A New Name'})
-          .then(() => notify('Todo save succeeded!'))
-          .catch(() => notify('Todo save failed :/'))
-          .then(() => this.setState({isSaving: false}));
-    }
-    ```
+  `resourcerer` only handles resource _fetching_ (i.e. calling [Model.prototype.fetch](/docs/model.md#fetch)). Note that this is not the same as only making `GET` requests; pass in a `method: 'POST'` property in a resource's config to turn the `params` property into a POST body, for example, when making a search request.
 
-* What about other data sources like websockets?  
+  For write operations, use Models' [`save`](/docs/model.md#save) and [`destroy`](/docs/model.md#destroy) methods directly:
 
-    `resourcerer` supports request/response-style semantics only. A similar package for declaratively linking message-pushing to React updates would be awesome&mdash;but it is not, at this point, part of this package.
+  ```js
+  onClickSaveButton() {
+    this.setState({isSaving: true});
 
-* How can we test components that use `resourcerer`?  
-  
-    See the [doc on testing components](/docs/testing_components.md) for more on that.
+    // any other mounted component in the application that uses this resource
+    // will get re-rendered with the updated name as soon as this is called
+    this.props.userTodoModel.save({name: 'Giving This Todo A New Name'})
+        .then(() => notify('Todo save succeeded!'))
+        .catch(() => notify('Todo save failed :/'))
+        .then(() => this.setState({isSaving: false}));
+  }
+  ```
 
-* How big is the `resourcerer` package?  
+- What about other data sources like websockets?
 
-    Under 10kB gzipped. It has no dependencies.
+  `resourcerer` supports request/response-style semantics only. A similar package for declaratively linking message-pushing to React updates would be awesome&mdash;but it is not, at this point, part of this package.
 
-* Semver?  
+- How can we test components that use `resourcerer`?
 
-    Yes. Releases will adhere to [semver](https://semver.org/#semantic-versioning-200) rules.
+  See the [doc on testing components](/docs/testing_components.md) for more on that.
+
+- How big is the `resourcerer` package?
+
+  Under 10kB gzipped. It has no dependencies.
+
+- Semver?
+
+  Yes. Releases will adhere to [semver](https://semver.org/#semantic-versioning-200) rules.
 
 # Migrating to v2.0
 

--- a/lib/resourcerer.ts
+++ b/lib/resourcerer.ts
@@ -382,8 +382,10 @@ export function useResources<T extends ResourceKeys>(
     // this will only return any passed-in (bypassed) models so we can override
     ...pick(props, ...Object.keys(models)),
 
-    refetch: (keys: ResourceKeys[]) => {
+    refetch: (keys: ResourceKeys | ResourceKeys[]) => {
       ReactDOM.unstable_batchedUpdates(() => {
+        keys = Array.isArray(keys) ? keys : [keys];
+
         keys.forEach((name) => {
           const model = getModelFromCache(findConfig([name, {}], getResources, props));
 
@@ -402,7 +404,8 @@ export function useResources<T extends ResourceKeys>(
     /**
      * For each resourceKey, find all entries in the cache and remove them.
      */
-    invalidate: (keys: ResourceKeys[]) => keys.forEach((key) => ModelCache.removeAllWithModel(key)),
+    invalidate: (keys: ResourceKeys | ResourceKeys[]) =>
+      (Array.isArray(keys) ? keys : [keys]).forEach((key) => ModelCache.removeAllWithModel(key)),
 
     setResourceState,
 

--- a/test/resourcerer.test.jsx
+++ b/test/resourcerer.test.jsx
@@ -1103,6 +1103,13 @@ describe("resourcerer", () => {
     expect(requestSpy.mock.calls.length).toEqual(5);
 
     await waitsFor(() => dataChild.props.hasLoaded);
+
+    // takes single key as arg
+    dataChild.props.refetch("decisions");
+
+    await waitsFor(() => !dataChild.props.hasLoaded);
+    await waitsFor(() => dataChild.props.hasLoaded);
+    expect(requestSpy.mock.calls.length).toEqual(6);
   });
 
   it("refetching in one component sets loading states in another", async () => {
@@ -1169,6 +1176,18 @@ describe("resourcerer", () => {
     expect(requestSpy.mock.calls.length).toEqual(5);
     expect(requestSpy.mock.calls.at(-1)[0]).toEqual("user~fraudLevel=high_userId=noah");
     expect(requestSpy.mock.calls.at(-2)[0]).toEqual("decisions");
+
+    // also accepts a single key as an arg
+    dataChild.props.invalidate("decisions");
+    ReactDOM.unmountComponentAtNode(renderNode);
+
+    dataChild = findDataChild(renderUseResources());
+    // now models are no longer in the cache
+    expect(dataChild.props.hasLoaded).not.toBe(true);
+
+    await waitsFor(() => dataChild.props.hasLoaded);
+    expect(requestSpy.mock.calls.length).toEqual(6);
+    expect(requestSpy.mock.calls.at(-1)[0]).toEqual("decisions");
   });
 
   it("fetches on mount (but not on updated) even when cached with 'force' option", async () => {


### PR DESCRIPTION
## Description of Proposed Changes:  
  -  `refetch` and `invalidate` functions can take a list of ResourceKeys but can now also just take a single resource key.

