### PR TITLE
Executor Fn second generic arg parameters

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -122,7 +122,7 @@ function MyComponent(props) {
     import {type ExecutorFunction, useResources} from 'resourcerer';
 
     // "todos" and "todoItem" will come up as type hints, both as the type parameters and the Resource Config Object keys
-    const getResources: ExecutorFunction<"todos" | "todoItem"> = (props: {orgId: string}) => ({
+    const getResources: ExecutorFunction<"todos" | "todoItem", {orgId: string}> = (props) => ({
        todos: {params: {orgId}},
        todoItem: {}
     });

--- a/lib/resourcerer.ts
+++ b/lib/resourcerer.ts
@@ -74,11 +74,11 @@ type ModelState = SetStateAction<Record<string, ModelInstanceType>>;
  *        fetched and cached
  *   * ...any other option that can be passed directly to the `request` function
  */
-export function useResources<T extends ResourceKeys>(
-  getResources: (props: Record<string, any>) => {
+export function useResources<T extends ResourceKeys, O extends Record<string, any>>(
+  getResources: (props: O) => {
     [Key in T]?: ResourceConfigObj;
   },
-  _props: Record<string, any>
+  _props: O
 ): UseResourcesResponse & {
   [Key in T as WithModelSuffix<Key, InstanceType<(typeof ModelMap)[Key]>>]: InstanceType<
     (typeof ModelMap)[Key]

--- a/resourcerer.d.ts
+++ b/resourcerer.d.ts
@@ -25,7 +25,7 @@ declare module "resourcerer" {
   export interface ModelMap {}
   export type ResourceKeys = Extract<keyof ModelMap, string>;
 
-  export type ExecutorFunction<T extends ResourceKeys, O = any> = (props: O) => {
+  export type ExecutorFunction<T extends ResourceKeys, O> = (props: O) => {
     [Key in T]?: ResourceConfigObj<Key>;
   };
 

--- a/resourcerer.d.ts
+++ b/resourcerer.d.ts
@@ -33,7 +33,7 @@ declare module "resourcerer" {
   export interface ModelMap {}
   export type ResourceKeys = Extract<keyof ModelMap, string>;
 
-  export type ExecutorFunction<T extends ResourceKeys, O> = (props: O) => {
+  export type ExecutorFunction<T extends ResourceKeys, O = Record<string, never>> = (props: O) => {
     [Key in T]?: ResourceConfigObj<Key>;
   };
 

--- a/resourcerer.d.ts
+++ b/resourcerer.d.ts
@@ -3,9 +3,9 @@ import Collection from "./build/lib/collection.js";
 
 export * from "./build/index.js";
 
-type GetPathOptions<C> =
-  C extends Model<infer A, infer O> ? O
-  : C extends Collection<infer M, infer CO> ? CO
+type GetModelOptions<C> =
+  C extends Model<infer A, infer O> ? [A, O]
+  : C extends Collection<infer M, infer O> ? [M, O]
   : never;
 
 declare module "resourcerer" {
@@ -13,13 +13,13 @@ declare module "resourcerer" {
     C extends Collection<any, any> ? `${K}Collection` : `${K}Model`;
   export type LoadingStates = "error" | "loading" | "loaded" | "pending";
   export type ResourceConfigObj<K extends ResourceKeys> = {
-    data?: { [key: string]: any };
+    data?: Partial<GetModelOptions<InstanceType<ModelMap[K]>>[0]>;
     dependsOn?: boolean;
     force?: boolean;
     lazy?: boolean;
     noncritical?: boolean;
     options?: { [key: string]: any };
-    path?: GetPathOptions<InstanceType<ModelMap[K]>>;
+    path?: GetModelOptions<InstanceType<ModelMap[K]>>[1];
     params?: { [key: string]: any };
     prefetches?: { [key: string]: any }[];
     provides?: (

--- a/resourcerer.d.ts
+++ b/resourcerer.d.ts
@@ -19,7 +19,9 @@ declare module "resourcerer" {
     lazy?: boolean;
     noncritical?: boolean;
     options?: { [key: string]: any };
-    path?: GetModelOptions<InstanceType<ModelMap[K]>>[1];
+    // ts is not happy with this but this will make our typings easier
+    // @ts-ignore
+    path?: Parameters<InstanceType<ModelMap[K]>["url"]>[0];
     params?: { [key: string]: any };
     prefetches?: { [key: string]: any }[];
     provides?: (

--- a/resourcerer.d.ts
+++ b/resourcerer.d.ts
@@ -1,6 +1,12 @@
+import Model from "./build/lib/model.js";
 import Collection from "./build/lib/collection.js";
 
 export * from "./build/index.js";
+
+type GetPathOptions<C> =
+  C extends Model<infer A, infer O> ? O
+  : C extends Collection<infer M, infer CO> ? CO
+  : never;
 
 declare module "resourcerer" {
   type WithModelSuffix<K extends ResourceKeys, C> =
@@ -13,7 +19,7 @@ declare module "resourcerer" {
     lazy?: boolean;
     noncritical?: boolean;
     options?: { [key: string]: any };
-    path?: { [key: string]: any };
+    path?: GetPathOptions<InstanceType<ModelMap[K]>>;
     params?: { [key: string]: any };
     prefetches?: { [key: string]: any }[];
     provides?: (


### PR DESCRIPTION
## Description of Proposed Changes:  
  -  Requires Executor Fn second generic argument if not just the empty object for props.

