### PR TITLE
better types for loading states and statuses

### DIFF
--- a/lib/resourcerer.ts
+++ b/lib/resourcerer.ts
@@ -83,6 +83,10 @@ export function useResources<T extends ResourceKeys, O extends Record<string, an
   [Key in T as WithModelSuffix<Key, InstanceType<(typeof ModelMap)[Key]>>]: InstanceType<
     (typeof ModelMap)[Key]
   >;
+} & {
+  [Key in T as `${T}LoadingState`]: LoadingStates;
+} & {
+  [Key in T as `${T}Status`]: number;
 } {
   const [resourceState, setResourceState] = useState<Record<string, any>>({});
   const props = { ..._props, ...resourceState };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -46,7 +46,8 @@ export type ExecutorFunction<
   T extends ResourceKeys = ResourceKeys,
   O extends { [key: string]: any } = any,
 > = (props: O) => {
-  [Key in T]?: Key extends ResourceKeys ? ResourceConfigObj : ResourceConfigObj & { resourceKey: T };
+  [Key in T]?: Key extends ResourceKeys ? ResourceConfigObj
+  : ResourceConfigObj & { resourceKey: T };
 };
 
 export type UseResourcesResponse = {
@@ -57,8 +58,4 @@ export type UseResourcesResponse = {
   refetch: (keys: ResourceKeys[]) => void;
   invalidate: (keys: ResourceKeys[]) => void;
   setResourceState(newState: { [key: string]: any }): void;
-  [key: `${string}LoadingState`]: LoadingStates;
-  [key: `${string}Collection`]: Collection;
-  [key: `${string}Model`]: Model;
-  [key: `${string}Status`]: number;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "2.0.0-beta-2",
+  "version": "2.0.0-beta-3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "2.0.0-beta-2",
+      "version": "2.0.0-beta-3",
       "devDependencies": {
         "@eslint/js": "^9.6.0",
         "@stylistic/eslint-plugin": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "2.0.0-beta-2",
+  "version": "2.0.0-beta-3",
   "repository": "github.com/noahgrant/resourcerer",
   "description": "Declarative data-fetching and caching framework for React",
   "keywords": ["declarative data-fetching framework", "react"],
@@ -9,7 +9,7 @@
   "types": "resourcerer.d.ts",
   "type": "module",
   "scripts": {
-    "checks": "npm typecheck && npm test && npm run lint",
+    "checks": "npm run typecheck && npm test && npm run lint",
     "lint": "eslint lib/*.ts* test/*.js*",
     "typecheck": "tsc --noEmit",
     "build": "tsc",

--- a/resourcerer.d.ts
+++ b/resourcerer.d.ts
@@ -45,8 +45,6 @@ declare module "resourcerer" {
     refetch: (keys: ResourceKeys | ResourceKeys[]) => void;
     invalidate: (keys: ResourceKeys | ResourceKeys[]) => void;
     setResourceState(newState: { [key: string]: any }): void;
-    [key: `${string}LoadingState`]: LoadingStates;
-    [key: `${string}Status`]: number;
   };
 
   export function useResources<T extends ResourceKeys, O extends Record<string, any>>(
@@ -54,5 +52,9 @@ declare module "resourcerer" {
     _props: O
   ): UseResourcesResponse & {
     [Key in T as WithModelSuffix<Key, InstanceType<ModelMap[Key]>>]: InstanceType<ModelMap[Key]>;
+  } & {
+    [Key in T as `${T}LoadingState`]: LoadingStates;
+  } & {
+    [Key in T as `${T}Status`]: number;
   };
 }


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
Currently any `${string}LoadingStates` and `${string}Status` fields would be present on a `UseResourcesResponse`, which means that any could be `LoadingStates | undefined` or `number | undefined`, respectively. This change means that the `undefined`s are only for the fields that shouldn't be present, and the resources requested will always have their loading state and status fields populated.