### PR TITLE
fix issue with lazy-loaded resources

### DIFF
--- a/lib/resourcerer.ts
+++ b/lib/resourcerer.ts
@@ -78,7 +78,7 @@ export function useResources<T extends ResourceKeys, O extends Record<string, an
   getResources: (props: O) => {
     [Key in T]?: ResourceConfigObj;
   },
-  _props: O,
+  _props: O
 ): UseResourcesResponse & {
   [Key in T as WithModelSuffix<Key, InstanceType<(typeof ModelMap)[Key]>>]: InstanceType<
     (typeof ModelMap)[Key]
@@ -100,7 +100,7 @@ export function useResources<T extends ResourceKeys, O extends Record<string, an
       loadingStates: initialLoadingStates,
       requestStatuses: {},
       hasInitiallyLoaded: hasLoaded(getCriticalLoadingStates(initialLoadingStates, resources)),
-    },
+    }
   );
   const criticalLoadingStates = getCriticalLoadingStates(loadingStates, resources);
   // we need to save our models as state using hooks because we can't defer
@@ -200,7 +200,7 @@ export function useResources<T extends ResourceKeys, O extends Record<string, an
     .filter(
       ([name, config]) =>
         prevPropsRef.current &&
-        hasAllDependencies(["", findConfig([name, config], getResources, prevPropsRef.current)]),
+        hasAllDependencies(["", findConfig([name, config], getResources, prevPropsRef.current)])
     );
   const resourcesToUpdate = getResourcesToUpdate();
   const nextLoadingStates: LoadingStateObj = {
@@ -211,14 +211,14 @@ export function useResources<T extends ResourceKeys, O extends Record<string, an
       // get partitioned into resourcesToFetch. this only happens on mount; on update, they
       // don't ever get included in resourcesToUpdate
       resourcesToUpdate.filter(withoutPrefetch).filter(withoutForced),
-      props,
+      props
     ),
   };
   // separate out those resources to update into those that are already cached and those
   // that need to be fetched. the former will get the models updated immediately
   const [loadedResources, resourcesToFetch] = partitionResources(
     resourcesToUpdate,
-    nextLoadingStates,
+    nextLoadingStates
   );
   // "cached" is a misnomer...
   const cachedResources = pendingResources
@@ -270,7 +270,7 @@ export function useResources<T extends ResourceKeys, O extends Record<string, an
   // that have lost their dependencies should go back to a pending state.
   if (
     Object.keys(nextLoadingStates).some(
-      (ky) => nextLoadingStates[ky as LoadingStateKey] !== loadingStates[ky as LoadingStateKey],
+      (ky) => nextLoadingStates[ky as LoadingStateKey] !== loadingStates[ky as LoadingStateKey]
     )
   ) {
     loaderDispatch({ type: "loading", payload: nextLoadingStates });
@@ -486,11 +486,11 @@ function generateResources(getResources: ExecutorFunction, props: Record<string,
                   ...getResources({ ...props, ...prefetch })[name],
                   prefetch: true,
                 },
-              ] as Resource,
-          ),
-        ),
+              ] as Resource
+          )
+        )
       ),
-    [] as Resource[],
+    [] as Resource[]
   );
 }
 
@@ -577,7 +577,7 @@ export function getCacheKey({
       .map((key) =>
         typeof key === "function" ?
           Object.entries(key(params)).map(toKeyValString).join("_")
-        : toKeyValString([key, path[key] || data[key] || params[key]]),
+        : toKeyValString([key, path[key] || data[key] || params[key]])
       )
       .filter(Boolean);
 
@@ -591,14 +591,14 @@ export function getCacheKey({
 function findConfig(
   [name, { prefetch }]: [string, { prefetch?: boolean }],
   getResources: ExecutorFunction,
-  props: Props,
+  props: Props
 ): InternalResourceConfigObj {
   const [, config = { resourceKey: "" }] =
     generateResources(getResources, props).find(
       ([_name, _config = {}]) =>
         name === _name &&
         // cheap deep equals
-        JSON.stringify(_config.prefetch) === JSON.stringify(prefetch),
+        JSON.stringify(_config.prefetch) === JSON.stringify(prefetch)
     ) || [];
 
   return config;
@@ -636,7 +636,7 @@ function findCacheKey(resource: Resource, getResources: ExecutorFunction, props:
 function buildResourcesLoadingState(
   resources: Resource[],
   props: Props,
-  defaultState: LoadingStates = "loaded",
+  defaultState: LoadingStates = "loaded"
 ): LoadingStateObj {
   return resources.reduce(
     (state, [name, config]) =>
@@ -656,7 +656,7 @@ function buildResourcesLoadingState(
             "loaded"
           : "loading",
       }),
-    {},
+    {}
   );
 }
 
@@ -753,7 +753,7 @@ function useIsMounted() {
  */
 function trackRequestTime(
   name: string,
-  { params, path }: { params?: Record<string, any>; path?: Record<string, any> } = {},
+  { params, path }: { params?: Record<string, any>; path?: Record<string, any> } = {}
 ) {
   const measurementName = `${name}Fetch`;
   let fetchEntry;
@@ -782,7 +782,7 @@ function trackRequestTime(
  */
 function getCriticalLoadingStates(
   loadingStates: LoadingStateObj,
-  resources: Resource[],
+  resources: Resource[]
 ): LoadingStates[] {
   return resources
     .filter(withoutNoncritical)
@@ -804,7 +804,7 @@ function modelAggregator(resources: Resource[]): SetStateAction<ModelState> {
         [getResourcePropertyName(name, config.resourceKey)]:
           getModelFromCache(config) || getEmptyModel(config),
       }),
-    {} as Record<string, ModelInstanceType>,
+    {} as Record<string, ModelInstanceType>
   );
 
   return (models = {}) =>
@@ -813,7 +813,7 @@ function modelAggregator(resources: Resource[]): SetStateAction<ModelState> {
         // this comparison is so that if no models have changed, we don't change state and rerender.
         // this is only important when a model is cached when a component mounts, because it will still
         // be included in resourcesToUpdate even though its model will be seeded in state already
-        (key) => models[key] !== newModels[key],
+        (key) => models[key] !== newModels[key]
       ).length
     ) ?
       { ...models, ...newModels }
@@ -829,7 +829,7 @@ function modelAggregator(resources: Resource[]): SetStateAction<ModelState> {
  */
 function partitionResources(
   resourcesToUpdate: Resource[],
-  loadingStates: Record<string, LoadingStates>,
+  loadingStates: Record<string, LoadingStates>
 ): [Resource[], Resource[]] {
   return resourcesToUpdate.reduce(
     (memo, [name, config]) =>
@@ -837,12 +837,13 @@ function partitionResources(
         config.refetch ||
         config.force ||
         config.prefetch ||
+        config.lazy ||
         !hasLoaded(loadingStates[getResourceState(name)] as LoadingStates) ||
         getModelFromCache(config)?.lazy
       ) ?
         [memo[0], memo[1].concat([[name, config]])]
       : [memo[0].concat([[name, config]]), memo[1]],
-    [[], []] as [Resource[], Resource[]],
+    [[], []] as [Resource[], Resource[]]
   );
 }
 
@@ -874,7 +875,7 @@ type LoaderState = {
 
 function loaderReducer(
   { loadingStates, requestStatuses, hasInitiallyLoaded }: LoaderState,
-  { type, payload = {} }: LoaderAction,
+  { type, payload = {} }: LoaderAction
 ): LoaderState {
   switch (type) {
     case "error":
@@ -960,10 +961,10 @@ function fetchResources(
     onRequestSuccess: (
       model: Model | Collection,
       status: number | undefined,
-      resource: Resource,
+      resource: Resource
     ) => void;
     onRequestFailure: (status: number, resource: Resource) => void;
-  },
+  }
 ) {
   // ensure critical requests go out first
   resources = resources.concat().sort((a, b) =>
@@ -971,7 +972,7 @@ function fetchResources(
     : b[1].prefetch ? -2
     : a[1].noncritical ? 1
     : b[1].noncritical ? -1
-    : 0,
+    : 0
   );
 
   return Promise.all(
@@ -1017,9 +1018,9 @@ function fetchResources(
           if (isCurrentResource([name, config], cacheKey)) {
             onRequestFailure(status, [name, config]);
           }
-        },
+        }
       );
-    }),
+    })
   );
 }
 
@@ -1030,7 +1031,7 @@ function provideProps(
   model: Model | Collection,
   provides: ResourceConfigObj["provides"],
   props: Props,
-  setResourceState: Dispatch<SetStateAction<Record<string, any>>>,
+  setResourceState: Dispatch<SetStateAction<Record<string, any>>>
 ) {
   if (provides) {
     setResourceState((state) => ({ ...state, ...provides(model, props) }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "2.0.2",
+      "version": "2.0.4",
       "devDependencies": {
         "@eslint/js": "^9.6.0",
         "@stylistic/eslint-plugin": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "repository": {
     "type": "git",
     "url": "github.com/noahgrant/resourcerer"

--- a/test/resourcerer.test.jsx
+++ b/test/resourcerer.test.jsx
@@ -16,7 +16,7 @@ import { findRenderedComponentWithType } from "react-dom/test-utils";
 import Model from "../lib/model";
 import ModelCache from "../lib/model-cache";
 import React from "react";
-import ReactDOM from "react-dom";
+import ReactDOM, { unmountComponentAtNode } from "react-dom";
 import { waitsFor } from "./test-utils";
 import { vi } from "vitest";
 
@@ -207,7 +207,7 @@ describe("resourcerer", () => {
         renderUseResources({
           decisionsCollection: new DecisionsCollection(),
           userModel: new UserModel(),
-        }),
+        })
       );
 
       expect(dataChild.props.hasInitiallyLoaded).toBe(true);
@@ -218,7 +218,7 @@ describe("resourcerer", () => {
           // analystsCollection is noncritical
           analystsCollection: new AnalystsCollection(),
           userModel: new UserModel(),
-        }),
+        })
       );
       expect(dataChild.props.hasInitiallyLoaded).toBe(false);
 
@@ -260,7 +260,7 @@ describe("resourcerer", () => {
       expect(dataChild.props.decisionsCollection instanceof DecisionsCollection).toBe(true);
       expect(dataChild.props.userModel instanceof UserModel).toBe(true);
       expect(dataChild.props.analystsCollection instanceof AnalystsCollection).toBe(true);
-    },
+    }
   );
 
   it("returns a setResourceState function that allows it to change resource-related props", async () => {
@@ -285,10 +285,10 @@ describe("resourcerer", () => {
       await waitsFor(() => requestSpy.mock.calls.length === 4);
 
       expect(requestSpy.mock.calls[requestSpy.mock.calls.length - 1][0]).toEqual(
-        "decisions~include_deleted=true",
+        "decisions~include_deleted=true"
       );
       expect(requestSpy.mock.calls[requestSpy.mock.calls.length - 1][1]).toEqual(
-        ModelMap.decisions,
+        ModelMap.decisions
       );
       expect(requestSpy.mock.calls[requestSpy.mock.calls.length - 1][2].params).toEqual({
         include_deleted: true,
@@ -335,7 +335,7 @@ describe("resourcerer", () => {
 
       expect(ModelCache.unregister).toHaveBeenCalledWith(
         componentRef,
-        "user~fraudLevel=high_userId=noah",
+        "user~fraudLevel=high_userId=noah"
       );
     });
 
@@ -511,7 +511,7 @@ describe("resourcerer", () => {
                 fraudLevel: "high",
                 lastName: "grant",
               },
-            }),
+            })
           ).toEqual("user~fraudLevel=high_userId=noah");
 
           expect(
@@ -522,9 +522,9 @@ describe("resourcerer", () => {
                 fraudLevel: "low",
                 lastName: "lopatron",
               },
-            }),
+            })
           ).toEqual("user~fraudLevel=low_userId=alex");
-        },
+        }
       );
 
       it("prioritizes dependencies in 'path' or 'data' config properties", () => {
@@ -533,7 +533,7 @@ describe("resourcerer", () => {
             params: { fraudLevel: "miniscule" },
             resourceKey: "user",
             path: { userId: "theboogieman" },
-          }),
+          })
         ).toEqual("user~fraudLevel=miniscule_userId=theboogieman");
       });
 
@@ -556,7 +556,7 @@ describe("resourcerer", () => {
               fraudLevel: "high",
               lastName: "grant",
             },
-          }),
+          })
         ).toEqual("user~fraudLevel=highgrant_lastName=grant_userId=noah");
 
         UserModel.dependencies = realDependencies;
@@ -798,7 +798,7 @@ describe("resourcerer", () => {
       expect(requestSpy.mock.calls.length).toEqual(4);
       expect(requestSpy.mock.calls.map((call) => call[0]).includes("actions")).toBe(true);
       expect(requestSpy.mock.calls[requestSpy.mock.calls.length - 1][0]).not.toMatch(
-        "decisionLogs",
+        "decisionLogs"
       );
 
       await waitsFor(() => dataChild.props.serialProp);
@@ -898,7 +898,7 @@ describe("resourcerer", () => {
         expect(
           requestSpy.mock.calls
             .filter((call) => /^searchQuery/.test(call[0]))
-            .map((call) => call[0]),
+            .map((call) => call[0])
         ).toEqual(["searchQuery", "searchQuery~from=10"]);
 
         await waitsFor(() => dataChild.props.hasLoaded);
@@ -911,7 +911,7 @@ describe("resourcerer", () => {
         expect(
           requestSpy.mock.calls
             .filter((call) => /^searchQuery/.test(call[0]))
-            .map((call) => call[0]),
+            .map((call) => call[0])
         ).toEqual(["searchQuery", "searchQuery~from=10", "searchQuery~from=20"]);
 
         expect(dataChild.props.searchQueryModel.params).toEqual({ from: 10 });
@@ -953,7 +953,7 @@ describe("resourcerer", () => {
                   res([model]);
                 }
               });
-            }),
+            })
         );
 
         dataChild = findDataChild(renderUseResources({ prefetch: true }));
@@ -1275,6 +1275,16 @@ describe("resourcerer", () => {
     dataChild = findDataChild(renderUseResources({ force: true }));
     await waitsFor(() => dataChild.props.hasLoaded);
     expect(requestSpy.mock.calls.length).toEqual(3);
+  });
+
+  it("lazily-fetched models are instances of their classes and not the empty model", async () => {
+    dataChild = findDataChild(renderUseResources({ lazy: true }));
+
+    expect(dataChild.props.decisionsCollection).toBeInstanceOf(DecisionsCollection);
+    await waitsFor(() => expect(dataChild.props.decisionsCollection.lazy).toBe(true));
+    expect(dataChild.props.decisionsCollection.isEmptyModel).not.toBe(true);
+
+    await waitsFor(() => dataChild.props.hasLoaded);
   });
 
   it("fetches lazily-cached resources", async () => {


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
- Fixes an issue where lazily-requested resources were short-circuiting the request flow because they were considered already loaded, and so they were returned as the frozen empty model.
