### PR TITLE
Fix loading state nonexclusive issue

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -7,10 +7,12 @@ export const hasErrored = (loadingStates: LoadingStates | LoadingStates[]): bool
   qualifyLoadingStates(loadingStates).some((state) => state === "error");
 
 /**
- * Returns true if any loadingStates are "loading". Can take a single or a list of LoadingStates.
+ * Returns true if any loadingStates are "loading" and none have errored, since once one has errored
+ * we know the whole group must be in an error state. Can take a single or a list of LoadingStates.
  */
 export const isLoading = (loadingStates: LoadingStates | LoadingStates[]): boolean =>
-  qualifyLoadingStates(loadingStates).some((state) => state === "loading");
+  qualifyLoadingStates(loadingStates).some((state) => state === "loading") &&
+  !qualifyLoadingStates(loadingStates).some((state) => state === "error");
 
 /**
  * Returns true if all loadingStates are "loaded". Can take a single or a list of LoadingStates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "devDependencies": {
         "@eslint/js": "^9.6.0",
         "@stylistic/eslint-plugin": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "repository": {
     "type": "git",
     "url": "github.com/noahgrant/resourcerer"

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -39,9 +39,10 @@ describe("Utils", () => {
 
   describe("isLoading method", () => {
     it("returns true if any loading state is loading", () => {
-      expect(isLoading(["error", "loading"])).toBe(true);
+      expect(isLoading(["pending", "loading", "loading"])).toBe(true);
+      expect(isLoading(["loaded", "loading"])).toBe(true);
       expect(isLoading("loading")).toBe(true);
-      expect(Utils.isLoading(["error", "loading"])).toBe(true);
+      expect(Utils.isLoading(["loaded", "loading"])).toBe(true);
       expect(Utils.isLoading("loading")).toBe(true);
     });
 
@@ -50,6 +51,11 @@ describe("Utils", () => {
       expect(isLoading("loaded")).toBe(false);
       expect(Utils.isLoading(["loaded", "loaded"])).toBe(false);
       expect(Utils.isLoading("loaded")).toBe(false);
+    });
+
+    it("returns false if any other loading states have errored", () => {
+      expect(isLoading(["error", "loading", "loaded"])).toBe(false);
+      expect(Utils.isLoading(["error", "loading", "loaded"])).toBe(false);
     });
 
     it("returns false if an undefined loading state is passed", () => {


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
A bug where a set of loading states could be both `hasErrored` and `isLoading` at the same time, which should not be possible. `hasErrored` is an end state like `hasLoaded`, so once one critical loading state reaches that, the entire loading state should be considered `hasErrored`.

## Description of Proposed Changes:  
  -  updates the `isLoading` utility function to also check that no loading states have errored

