### PR TITLE
accept custom model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "devDependencies": {
         "@eslint/js": "^9.6.0",
         "@stylistic/eslint-plugin": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "repository": {
     "type": "git",
     "url": "github.com/noahgrant/resourcerer"


### PR DESCRIPTION
## Fixes (includes issue number if applicable):
- Fixes the type issue where passing a `static Model = MyNewModelClass;` was not being honored by a collection. Adds an optional generic to the collection to address this. No runtime code changed.