### PR TITLE
Canonical Models and subscriptions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 export { default as Collection } from "./lib/collection.js";
-export { default as Model } from "./lib/model.js";
+export { default as CanonicalModel } from "./lib/canonical-model.js";
+export { default as Model, type CanonicalModelSubscription } from "./lib/model.js";
 export { default as sync, ajax, type SyncOptions } from "./lib/sync.js";
 export { default as prefetch } from "./lib/prefetch.js";
 export { default as request } from "./lib/request.js";

--- a/lib/canonical-model-cache.ts
+++ b/lib/canonical-model-cache.ts
@@ -1,0 +1,60 @@
+import CanonicalModel from "./canonical-model.js";
+
+// canonical models are not managed in React, they are managed within our models
+// exported for testing
+export const canonicalModelCache = new Map<
+  typeof CanonicalModel<any>,
+  Map<string | number, CanonicalModel<any>>
+>();
+
+/**
+ * This is the interface for interacting with our canonical model cache map. That map is where we
+ * store all canonical models as long as they have subscriptions. It should never be used
+ * externally; the only way to add to the cache is via the .getOrCreate method, which will always
+ * return a model.
+ *
+ * The map is a map of model classes to maps of ids to canonical models:
+ *   Map<ModelClass, Map<id, CanonicalModel>>
+ */
+const CanonicalModelCache = {
+  /**
+   * This getter method also actually sets if the model doesn't exist. When we call get from the
+   * cache we want to know for sure that we are returning a new model for the given id.
+   */
+  getOrInsert(ModelClass: typeof CanonicalModel<any>, id: string | number) {
+    const existingCachedModel = canonicalModelCache.get(ModelClass)?.get(id);
+
+    if (existingCachedModel) {
+      return existingCachedModel;
+    }
+
+    const newCanonicalModel = new ModelClass();
+
+    this.set(ModelClass, id, newCanonicalModel);
+
+    return newCanonicalModel;
+  },
+
+  /**
+   * We should never call this directly; the only time we add to the cache is when we call
+   * the .get and nothing exists yet.
+   */
+  set(ModelClass: typeof CanonicalModel<any>, id: string | number, model: CanonicalModel<any>) {
+    // this is a map, for this class, of ids to canonical models. defaults to a new one
+    const canonicalModelMap =
+      canonicalModelCache.get(ModelClass) || new Map<string, CanonicalModel<any>>();
+
+    canonicalModelMap.set(id, model);
+    canonicalModelCache.set(ModelClass, canonicalModelMap);
+  },
+
+  remove(ModelClass: typeof CanonicalModel<any>, id: string | number) {
+    const canonicalModelMap = canonicalModelCache.get(ModelClass);
+
+    if (canonicalModelMap) {
+      canonicalModelMap.delete(id);
+    }
+  },
+};
+
+export default CanonicalModelCache;

--- a/lib/canonical-model.ts
+++ b/lib/canonical-model.ts
@@ -1,0 +1,72 @@
+import { isDeepEqual } from "./utils.js";
+import Events from "./events.js";
+import Model from "./model.js";
+import CanonicalModelCache from "./canonical-model-cache.js";
+
+/**
+ * This is a very basic class for canonical models. It really has one responsibility: trigger
+ * updates when its attributes change via its `set` method. It extends the Events class to allow
+ * for regular models to subscribe to its updates.
+ *
+ * Only models subscribe to canonical models - collections do not; they just have their models
+ * within them subscribe. When a subscribing model is updated, it updates the canonical model,
+ * as well. This in turn triggers updates for all other subscribing models, and is how we can
+ * keep related but different models in sync throughout an application.
+ *
+ * There's no notion of an id in this file, but a canonical model won't be instantiated
+ * without one. It's from this id that we put the instance in the cache and then can refrenece
+ * it when a subscribing model is updated (as in, an entire model class will be defined as
+ * subscribing to a canonical model class, but in reality it's a model instance that will get
+ * subscribed to a canonical model instance of the same id.
+ */
+export default class CanonicalModel<T extends Record<string, any>> extends Events<
+  [Partial<T>, Model]
+> {
+  attributes: T = {} as T;
+
+  get<K extends keyof T>(attr: K): T[K] {
+    return this.attributes[attr];
+  }
+
+  set(attrs: Partial<T> = {}, context: Model, options: { unset?: boolean } = {}): void {
+    let hasSomethingChanged = false;
+
+    // for each `set` attribute, update or delete the current value, and mark whether any in the
+    // lot have changed. this will be used to determine whether to trigger an update.
+    for (let attr of Object.keys(attrs)) {
+      if (!hasSomethingChanged && !isDeepEqual(this.attributes[attr], attrs[attr] as T[keyof T])) {
+        hasSomethingChanged = true;
+      }
+
+      options.unset ?
+        delete this.attributes[attr]
+      : (this.attributes[attr as keyof T] = attrs[attr] as T[keyof T]);
+    }
+
+    if (hasSomethingChanged) {
+      // the context is important here - we don't want to update the same model that just
+      // set the canonical model's attributes in the first place
+      this.triggerUpdate(this.toJSON(), context);
+    }
+  }
+
+  /**
+   * Canonical models are totally kept outside the React lifecycle, which is nice. We don't boot
+   * them from the cache when components get unmounted, for example. We only remove them when there
+   * are no more subscriptions. Models will unsubscribe they are deleted (destroyed), when they're
+   * removed from a collection, or when they or their collection is removed from the cache.
+   */
+  removeSubscription(context: Model<any, any>, id: string | number) {
+    this.offUpdate(context);
+
+    if (!this._callbacks.length) {
+      CanonicalModelCache.remove(this.constructor as typeof CanonicalModel<any>, id);
+    }
+  }
+
+  toJSON(): T {
+    return { ...this.attributes };
+  }
+}
+
+Object.assign(CanonicalModel.prototype, Events);

--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -36,7 +36,7 @@ export default class Collection<
   T extends Record<string, any> = object,
   O extends Record<string, any> = object,
   M extends typeof Model<T, O> = typeof Model<T, O>,
-> extends Events {
+> extends Events<[]> {
   lazy?: boolean;
   refetching?: boolean;
   measure?: boolean | ((config: ResourceConfigObj) => boolean);
@@ -417,6 +417,14 @@ export default class Collection<
   }
 
   /**
+   * This will unsubscribe all models in the collection, which will happen whenever the collection
+   * is removed from the cache.
+   */
+  unsubscribe() {
+    this.models.forEach((model) => model.unsubscribe());
+  }
+
+  /**
    * This function gets called when the collection is instantiated, and its return value is set to
    * its Model property (and used to instantiate all its models). It's only used if a `Model`
    * option isn't passed to the constructor, and by default it returns the Model base class. But
@@ -539,6 +547,7 @@ export default class Collection<
     delete model.collection;
 
     model.offUpdate(this);
+    model.unsubscribe();
   }
 
   /**

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,5 +1,5 @@
-type CallbackEntry = {
-  callback: (...args: any[]) => void;
+type CallbackEntry<Args extends any[]> = {
+  callback: (...args: Args) => void;
   context: NonNullable<unknown>;
 };
 
@@ -17,18 +17,18 @@ export interface Events {
  * about event names, nor event arguments. On every trigger, we're going to fire all callbacks.
  * And when removing the listener, all we need is the context (which is the component).
  */
-export default class Events {
-  _callbacks: CallbackEntry[] = [];
+export default class Events<Args extends any[] = []> {
+  _callbacks: CallbackEntry<Args>[] = [];
 
-  triggerUpdate() {
-    this._callbacks?.forEach(({ callback, context }) => callback.call(context));
+  triggerUpdate(...args: Args) {
+    this._callbacks?.forEach(({ callback, context }) => callback.call(context, ...args));
   }
 
-  onUpdate(callback: CallbackEntry["callback"], context: CallbackEntry["context"]) {
+  onUpdate(callback: CallbackEntry<Args>["callback"], context: CallbackEntry<Args>["context"]) {
     this._callbacks = (this._callbacks || []).concat({ callback, context });
   }
 
-  offUpdate(ctx: CallbackEntry["context"]) {
+  offUpdate(ctx: CallbackEntry<Args>["context"]) {
     this._callbacks = (this._callbacks || []).filter(({ context }) => context !== ctx);
   }
 }

--- a/lib/model-cache.ts
+++ b/lib/model-cache.ts
@@ -140,9 +140,10 @@ function scheduleForRemoval(cacheKey: string) {
 }
 
 /**
- * Remove a model from the cache.
+ * Remove a model from the cache, unsubscribing from any canonical models.
  */
 function clearModel(cacheKey: string) {
+  modelCache.get(cacheKey)?.unsubscribe();
   window.clearTimeout(timeouts[cacheKey]);
   delete timeouts[cacheKey];
   modelCache.delete(cacheKey);

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -1,18 +1,34 @@
-import { isDeepEqual, result, uniqueId, urlError } from "./utils.js";
+import { getNestedValue, isDeepEqual, result, uniqueId, urlError } from "./utils.js";
 
 import Events from "./events.js";
 import sync, { type SyncOptions } from "./sync.js";
 import Collection from "./collection.js";
-import { ResourceConfigObj } from "./types.js";
+import { NestedKeys, ResourceConfigObj } from "./types.js";
+import CanonicalModel from "./canonical-model.js";
+import CanonicalModelCache from "./canonical-model-cache.js";
 
 export type ConstructorOptions = {
   collection?: Collection;
   parse?: boolean;
 };
 
+export type CanonicalModelSubscription<
+  M extends Record<string, any> = Record<string, any>,
+  C extends Record<string, any> = Record<string, any>,
+> = {
+  Model: typeof CanonicalModel<C>;
+  // notably, for our subscriptions, this is the field that corresponds
+  // to the canonical model's id, not the field for the subscribing model's id
+  idField?: NestedKeys<M>;
+  fromSource?: (attrs: Partial<C>, currentTarget: Partial<M>) => Partial<M>;
+  toSource?: (attrs: Partial<M>, currentSource: Partial<C>) => Partial<C>;
+};
+
 export type SetOptions = {
   silent?: boolean;
   unset?: boolean;
+  source?: "subscription" | "self";
+  subscribe?: boolean;
 };
 
 const RESERVED_OPTION_KEYS = [
@@ -40,7 +56,7 @@ const RESERVED_OPTION_KEYS = [
 export default class Model<
   T extends Record<string, any> = Record<string, any>,
   O extends Record<string, any> = Record<string, any>,
-> extends Events {
+> extends Events<[]> {
   cid: string;
   id: string | number;
   attributes: T;
@@ -62,8 +78,8 @@ export default class Model<
    *     passed to the `url` function
    */
   constructor(
-    attributes?: T,
-    options: O & SetOptions & ConstructorOptions = {} as O & SetOptions & ConstructorOptions
+    attributes?: Partial<T>,
+    options: O & SetOptions & ConstructorOptions = {} as O & SetOptions & ConstructorOptions,
   ) {
     super();
 
@@ -81,10 +97,14 @@ export default class Model<
     this.urlOptions = Object.keys(options).reduce(
       (memo, key) =>
         Object.assign(memo, !RESERVED_OPTION_KEYS.includes(key) ? { [key]: options[key] } : {}),
-      {} as O
+      {} as O,
     );
 
     this.set({ ...result(this.constructor, "defaults"), ...attributes }, options);
+
+    if (options.subscribe !== false) {
+      this._subscribe();
+    }
   }
 
   /**
@@ -120,6 +140,8 @@ export default class Model<
    */
   static measure: boolean | ((config: ResourceConfigObj) => boolean) = false;
 
+  static subscriptions: CanonicalModelSubscription[] = [];
+
   /**
    * Returns a copy of the model's `attributes` object. Use this method to get the current entire
    * server data representation.
@@ -148,7 +170,7 @@ export default class Model<
   pick<K extends keyof T>(...attrs: K[]): Pick<T, K> {
     return attrs.reduce(
       (memo, attr) => Object.assign(memo, this.has(attr) ? { [attr]: this.get(attr) } : {}),
-      {} as Pick<T, K>
+      {} as Pick<T, K>,
     );
   }
 
@@ -178,6 +200,12 @@ export default class Model<
       options.unset ?
         delete this.attributes[attr]
       : (this.attributes[attr as keyof T] = attrs[attr] as T[keyof T]);
+    }
+
+    // the option.source check is to prevent infinite loops of updates
+    // the option.subscribe check is to prevent updating from the empty model
+    if (hasSomethingChanged && options.source !== "subscription" && options.subscribe !== false) {
+      this._updateSubscriptions(attrs, options);
     }
 
     // Update the `id`.
@@ -230,6 +258,7 @@ export default class Model<
       const serverAttrs = options.parse ? this.parse(json, options) : json;
 
       this.set(serverAttrs, options);
+      this._subscribe();
       // sync update
       this.triggerUpdate();
 
@@ -244,7 +273,7 @@ export default class Model<
    */
   save(
     attrs: Partial<T>,
-    options: { wait?: boolean; patch?: boolean } & SyncOptions & SetOptions = {}
+    options: { wait?: boolean; patch?: boolean } & SyncOptions & SetOptions = {},
   ): Promise<[this, Response]> {
     const previousAttributes = this.toJSON();
 
@@ -267,7 +296,7 @@ export default class Model<
       options.attrs = attrs;
     }
 
-    return this.sync(this, options)
+    return this.sync(this as Model | Collection, options)
       .then(([json, response]) => {
         let serverAttrs = options.parse ? this.parse(json, options) : json;
 
@@ -277,6 +306,7 @@ export default class Model<
 
         // avoid triggering any updates in the set call since we'll do it immediately after
         this.set(serverAttrs, { silent: true, ...options });
+        this._subscribe();
         // sync update
         this.triggerUpdate();
 
@@ -301,7 +331,9 @@ export default class Model<
    */
   destroy(options: { wait?: boolean } & SyncOptions & SetOptions = {}): Promise<[this, Response]> {
     const request =
-        this.isNew() ? Promise.resolve([]) : this.sync(this, { method: "DELETE", ...options }),
+        this.isNew() ?
+          Promise.resolve([])
+        : this.sync(this as Model | Collection, { method: "DELETE", ...options }),
       collection = this.collection;
 
     if (!options.wait) {
@@ -314,6 +346,7 @@ export default class Model<
         if (options.wait && !this.isNew()) {
           this.triggerUpdate();
           this.collection?.remove(this, { silent: true });
+          this.unsubscribe();
         }
 
         return [this, response] as [this, Response];
@@ -362,6 +395,91 @@ export default class Model<
    */
   isNew() {
     return !this.has((this.constructor as typeof Model).idAttribute);
+  }
+
+  /**
+   * This gets called:
+   * - when a model is instantiated (ie directly or when it is added to a collection)
+   * - when a model completes a fetch
+   * - when a model is saved
+   *
+   * This should only happen when the model has the id field set for the canonical model. And
+   * if we've already subscribed, this should have no effect.
+   */
+  _subscribe() {
+    const { subscriptions, idAttribute } = this.constructor as typeof Model;
+
+    for (const { Model: CanonicalModel, idField = idAttribute, fromSource } of subscriptions) {
+      const id = getNestedValue(this.toJSON(), idField);
+
+      if (id && !this.isEmptyModel) {
+        const canonicalModel = CanonicalModelCache.getOrInsert(CanonicalModel, id);
+
+        // remove any existing subscriptions. this could be more efficient.
+        canonicalModel.offUpdate(this);
+
+        /**
+         * This callback will get invoked when the canonical model is updated by any other
+         * subscribing model.
+         */
+        canonicalModel.onUpdate((canonicalAttrs, context) => {
+          // this will keep us from an infinite loop of updates
+          if (context === this || !fromSource) {
+            return;
+          }
+
+          this.set(fromSource(canonicalAttrs, this.toJSON()) as Partial<T>, {
+            source: "subscription",
+          });
+        }, this);
+      }
+    }
+  }
+
+  /**
+   * This gets called:
+   * - when it or its collection is removed from the cache
+   * - when a model is removed from a collection
+   * - when a model is destroyed
+   *
+   * Notably, it is never called in the context of the react lifecycle.
+   */
+  unsubscribe() {
+    const { subscriptions, idAttribute } = this.constructor as typeof Model;
+
+    for (const { Model: CanonicalModel, idField = idAttribute } of subscriptions) {
+      const id = getNestedValue(this.toJSON(), idField);
+
+      if (id) {
+        const canonicalModel = CanonicalModelCache.getOrInsert(CanonicalModel, id);
+
+        canonicalModel.removeSubscription(this, id);
+      }
+    }
+  }
+
+  /**
+   * This will get called when this model is set. It then needs to update any canonical models
+   * it is subscribed to.
+   */
+  _updateSubscriptions(attrs: Partial<T>, options: SetOptions): void {
+    const { subscriptions, idAttribute } = this.constructor as typeof Model;
+
+    for (const { Model: CanonicalModel, idField = idAttribute, toSource } of subscriptions) {
+      const id = getNestedValue(this.toJSON(), idField);
+
+      // TODO: this breaks if the id itself changes because it's no longer keyed correctly in the cache
+      // should we prohibit the id attribute from being changed by not passing it to set?
+      if (toSource && id && !this.isEmptyModel) {
+        const canonicalModel = CanonicalModelCache.getOrInsert(CanonicalModel, id);
+
+        canonicalModel.set(
+          toSource({ ...this.attributes, ...attrs }, canonicalModel.toJSON()),
+          this as Model,
+          options,
+        );
+      }
+    }
   }
 }
 

--- a/lib/resourcerer.ts
+++ b/lib/resourcerer.ts
@@ -78,7 +78,7 @@ export function useResources<T extends ResourceKeys, O extends Record<string, an
   getResources: (props: O) => {
     [Key in T]?: ResourceConfigObj;
   },
-  _props: O
+  _props: O,
 ): UseResourcesResponse & {
   [Key in T as WithModelSuffix<Key, InstanceType<(typeof ModelMap)[Key]>>]: InstanceType<
     (typeof ModelMap)[Key]
@@ -100,7 +100,7 @@ export function useResources<T extends ResourceKeys, O extends Record<string, an
       loadingStates: initialLoadingStates,
       requestStatuses: {},
       hasInitiallyLoaded: hasLoaded(getCriticalLoadingStates(initialLoadingStates, resources)),
-    }
+    },
   );
   const criticalLoadingStates = getCriticalLoadingStates(loadingStates, resources);
   // we need to save our models as state using hooks because we can't defer
@@ -200,7 +200,7 @@ export function useResources<T extends ResourceKeys, O extends Record<string, an
     .filter(
       ([name, config]) =>
         prevPropsRef.current &&
-        hasAllDependencies(["", findConfig([name, config], getResources, prevPropsRef.current)])
+        hasAllDependencies(["", findConfig([name, config], getResources, prevPropsRef.current)]),
     );
   const resourcesToUpdate = getResourcesToUpdate();
   const nextLoadingStates: LoadingStateObj = {
@@ -211,14 +211,14 @@ export function useResources<T extends ResourceKeys, O extends Record<string, an
       // get partitioned into resourcesToFetch. this only happens on mount; on update, they
       // don't ever get included in resourcesToUpdate
       resourcesToUpdate.filter(withoutPrefetch).filter(withoutForced),
-      props
+      props,
     ),
   };
   // separate out those resources to update into those that are already cached and those
   // that need to be fetched. the former will get the models updated immediately
   const [loadedResources, resourcesToFetch] = partitionResources(
     resourcesToUpdate,
-    nextLoadingStates
+    nextLoadingStates,
   );
   // "cached" is a misnomer...
   const cachedResources = pendingResources
@@ -270,7 +270,7 @@ export function useResources<T extends ResourceKeys, O extends Record<string, an
   // that have lost their dependencies should go back to a pending state.
   if (
     Object.keys(nextLoadingStates).some(
-      (ky) => nextLoadingStates[ky as LoadingStateKey] !== loadingStates[ky as LoadingStateKey]
+      (ky) => nextLoadingStates[ky as LoadingStateKey] !== loadingStates[ky as LoadingStateKey],
     )
   ) {
     loaderDispatch({ type: "loading", payload: nextLoadingStates });
@@ -486,11 +486,11 @@ function generateResources(getResources: ExecutorFunction, props: Record<string,
                   ...getResources({ ...props, ...prefetch })[name],
                   prefetch: true,
                 },
-              ] as Resource
-          )
-        )
+              ] as Resource,
+          ),
+        ),
       ),
-    [] as Resource[]
+    [] as Resource[],
   );
 }
 
@@ -540,8 +540,8 @@ function getResourcePropertyName(baseName: string, resourceKey: string) {
  */
 function getEmptyModel({ resourceKey, data, options, path }: InternalResourceConfigObj) {
   const Model_ = typeof ModelMap[resourceKey] === "function" ? ModelMap[resourceKey] : Model;
-  // @ts-ignore
-  const emptyInstance = new Model_(data, { ...options, ...path });
+
+  const emptyInstance = new Model_!(data, { ...options, ...path, subscribe: false });
 
   // flag to differentiate between other model instances that happen to be empty
   (emptyInstance as ModelInstanceType).isEmptyModel = true;
@@ -577,7 +577,7 @@ export function getCacheKey({
       .map((key) =>
         typeof key === "function" ?
           Object.entries(key(params)).map(toKeyValString).join("_")
-        : toKeyValString([key, path[key] || data[key] || params[key]])
+        : toKeyValString([key, path[key] || data[key] || params[key]]),
       )
       .filter(Boolean);
 
@@ -591,14 +591,14 @@ export function getCacheKey({
 function findConfig(
   [name, { prefetch }]: [string, { prefetch?: boolean }],
   getResources: ExecutorFunction,
-  props: Props
+  props: Props,
 ): InternalResourceConfigObj {
   const [, config = { resourceKey: "" }] =
     generateResources(getResources, props).find(
       ([_name, _config = {}]) =>
         name === _name &&
         // cheap deep equals
-        JSON.stringify(_config.prefetch) === JSON.stringify(prefetch)
+        JSON.stringify(_config.prefetch) === JSON.stringify(prefetch),
     ) || [];
 
   return config;
@@ -636,7 +636,7 @@ function findCacheKey(resource: Resource, getResources: ExecutorFunction, props:
 function buildResourcesLoadingState(
   resources: Resource[],
   props: Props,
-  defaultState: LoadingStates = "loaded"
+  defaultState: LoadingStates = "loaded",
 ): LoadingStateObj {
   return resources.reduce(
     (state, [name, config]) =>
@@ -656,7 +656,7 @@ function buildResourcesLoadingState(
             "loaded"
           : "loading",
       }),
-    {}
+    {},
   );
 }
 
@@ -753,7 +753,7 @@ function useIsMounted() {
  */
 function trackRequestTime(
   name: string,
-  { params, path }: { params?: Record<string, any>; path?: Record<string, any> } = {}
+  { params, path }: { params?: Record<string, any>; path?: Record<string, any> } = {},
 ) {
   const measurementName = `${name}Fetch`;
   let fetchEntry;
@@ -782,7 +782,7 @@ function trackRequestTime(
  */
 function getCriticalLoadingStates(
   loadingStates: LoadingStateObj,
-  resources: Resource[]
+  resources: Resource[],
 ): LoadingStates[] {
   return resources
     .filter(withoutNoncritical)
@@ -804,7 +804,7 @@ function modelAggregator(resources: Resource[]): SetStateAction<ModelState> {
         [getResourcePropertyName(name, config.resourceKey)]:
           getModelFromCache(config) || getEmptyModel(config),
       }),
-    {} as Record<string, ModelInstanceType>
+    {} as Record<string, ModelInstanceType>,
   );
 
   return (models = {}) =>
@@ -813,7 +813,7 @@ function modelAggregator(resources: Resource[]): SetStateAction<ModelState> {
         // this comparison is so that if no models have changed, we don't change state and rerender.
         // this is only important when a model is cached when a component mounts, because it will still
         // be included in resourcesToUpdate even though its model will be seeded in state already
-        (key) => models[key] !== newModels[key]
+        (key) => models[key] !== newModels[key],
       ).length
     ) ?
       { ...models, ...newModels }
@@ -829,7 +829,7 @@ function modelAggregator(resources: Resource[]): SetStateAction<ModelState> {
  */
 function partitionResources(
   resourcesToUpdate: Resource[],
-  loadingStates: Record<string, LoadingStates>
+  loadingStates: Record<string, LoadingStates>,
 ): [Resource[], Resource[]] {
   return resourcesToUpdate.reduce(
     (memo, [name, config]) =>
@@ -843,7 +843,7 @@ function partitionResources(
       ) ?
         [memo[0], memo[1].concat([[name, config]])]
       : [memo[0].concat([[name, config]]), memo[1]],
-    [[], []] as [Resource[], Resource[]]
+    [[], []] as [Resource[], Resource[]],
   );
 }
 
@@ -875,7 +875,7 @@ type LoaderState = {
 
 function loaderReducer(
   { loadingStates, requestStatuses, hasInitiallyLoaded }: LoaderState,
-  { type, payload = {} }: LoaderAction
+  { type, payload = {} }: LoaderAction,
 ): LoaderState {
   switch (type) {
     case "error":
@@ -961,10 +961,10 @@ function fetchResources(
     onRequestSuccess: (
       model: Model | Collection,
       status: number | undefined,
-      resource: Resource
+      resource: Resource,
     ) => void;
     onRequestFailure: (status: number, resource: Resource) => void;
-  }
+  },
 ) {
   // ensure critical requests go out first
   resources = resources.concat().sort((a, b) =>
@@ -972,7 +972,7 @@ function fetchResources(
     : b[1].prefetch ? -2
     : a[1].noncritical ? 1
     : b[1].noncritical ? -1
-    : 0
+    : 0,
   );
 
   return Promise.all(
@@ -1018,9 +1018,9 @@ function fetchResources(
           if (isCurrentResource([name, config], cacheKey)) {
             onRequestFailure(status, [name, config]);
           }
-        }
+        },
       );
-    })
+    }),
   );
 }
 
@@ -1031,7 +1031,7 @@ function provideProps(
   model: Model | Collection,
   provides: ResourceConfigObj["provides"],
   props: Props,
-  setResourceState: Dispatch<SetStateAction<Record<string, any>>>
+  setResourceState: Dispatch<SetStateAction<Record<string, any>>>,
 ) {
   if (provides) {
     setResourceState((state) => ({ ...state, ...provides(model, props) }));

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -60,3 +60,21 @@ export type UseResourcesResponse = {
   invalidate: typeof invalidate;
   setResourceState(newState: { [key: string]: any }): void;
 };
+
+// limit this to 3 levels deep because sometimes objects can reference themselves
+export type NestedKeys<T, Depth extends number = 3> =
+  Depth extends 0 ? never
+  : T extends Record<string, any> ?
+    {
+      [K in Extract<keyof T, string>]: T[K] extends Record<string, any> | undefined ?
+        | `${K}`
+        | `${K}.${NestedKeys<
+            Exclude<T[K], undefined>,
+            Depth extends 1 ? 0
+            : Depth extends 2 ? 1
+            : Depth extends 3 ? 2
+            : never
+          >}`
+      : `${K}`;
+    }[Extract<keyof T, string>]
+  : never;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -55,7 +55,7 @@ export function pick<T, K extends keyof T>(obj: T = {} as T, ...keys: K[]) {
 
       return memo;
     },
-    {} as { [P in K]: T[P] }
+    {} as { [P in K]: T[P] },
   );
 }
 
@@ -160,4 +160,11 @@ export function sortBy(list: any[] = [], comparator: (val: any) => string | numb
  */
 export function result(obj: Record<string, any> = {}, prop: string, ...args: any[]) {
   return typeof obj[prop] === "function" ? obj[prop](...args) : obj[prop];
+}
+
+/**
+ * Gets the value of a nested property in an object. The path is a string of dot-separated keys.
+ */
+export function getNestedValue(obj: Record<string, any>, path: string): any {
+  return path.split(".").reduce((acc, key) => acc?.[key], obj);
 }

--- a/test/canonical-model-cache.test.js
+++ b/test/canonical-model-cache.test.js
@@ -1,0 +1,75 @@
+import CanonicalModelCache from "../lib/canonical-model-cache";
+import CanonicalModel from "../lib/canonical-model";
+import { beforeEach, vi } from "vitest";
+
+class CanonicalTestModel extends CanonicalModel {}
+
+describe("CanonicalModelCache", () => {
+  beforeEach(() => {
+    vi.spyOn(CanonicalModelCache, "set");
+    CanonicalModelCache.remove(CanonicalTestModel, "1234");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("getOrInsert", () => {
+    it("returns the canonical model for the given id", () => {
+      const testModel = new CanonicalTestModel();
+
+      CanonicalModelCache.set(CanonicalTestModel, "1234", testModel);
+      CanonicalModelCache.set.mockClear();
+
+      const canonicalModel = CanonicalModelCache.getOrInsert(CanonicalTestModel, "1234");
+
+      expect(canonicalModel).toBeDefined();
+      expect(canonicalModel).toEqual(testModel);
+      expect(CanonicalModelCache.set).not.toHaveBeenCalled();
+    });
+
+    it("creates a new canonical model if one doesn't exist", () => {
+      const canonicalModel = CanonicalModelCache.getOrInsert(CanonicalTestModel, "1234");
+
+      expect(canonicalModel).toBeDefined();
+      expect(CanonicalModelCache.set).toHaveBeenCalledWith(
+        CanonicalTestModel,
+        "1234",
+        canonicalModel,
+      );
+    });
+  });
+
+  describe("set", () => {
+    it("adds a canonical model to the cache at its id and model class", () => {
+      const canonicalModel = new CanonicalTestModel();
+      const canonicalModel2 = new CanonicalTestModel();
+
+      CanonicalModelCache.set(CanonicalTestModel, "1234", canonicalModel);
+      CanonicalModelCache.set(CanonicalTestModel, "1235", canonicalModel2);
+      expect(CanonicalModelCache.getOrInsert(CanonicalTestModel, "1234")).toEqual(canonicalModel);
+      expect(CanonicalModelCache.getOrInsert(CanonicalTestModel, "1235")).toEqual(canonicalModel2);
+
+      CanonicalModelCache.remove(CanonicalTestModel, "1235");
+    });
+
+    it("creates a new map for the model class if one doesn't exist", () => {
+      const canonicalModel = new CanonicalTestModel();
+
+      CanonicalModelCache.set(CanonicalTestModel, "1234", canonicalModel);
+      expect(CanonicalModelCache.getOrInsert(CanonicalTestModel, "1234")).toEqual(canonicalModel);
+    });
+  });
+
+  describe("remove", () => {
+    it("removes a canonical model from the cache", () => {
+      const canonicalModel = new CanonicalTestModel();
+
+      vi.spyOn(Map.prototype, "delete");
+      CanonicalModelCache.set(CanonicalTestModel, "1234", canonicalModel);
+      CanonicalModelCache.remove(CanonicalTestModel, "1234");
+
+      expect(Map.prototype.delete).toHaveBeenCalledWith("1234");
+    });
+  });
+});

--- a/test/canonical-model.test.js
+++ b/test/canonical-model.test.js
@@ -1,0 +1,87 @@
+import CanonicalModelCache from "../lib/canonical-model-cache";
+import Model from "../lib/model";
+import { vi } from "vitest";
+import CanonicalModel from "../lib/canonical-model";
+
+class CanonicalTestModel extends CanonicalModel {}
+
+describe("CanonicalModel", () => {
+  let model;
+  let context = {};
+  const callback = vi.fn();
+
+  afterEach(() => {
+    callback.mockClear();
+  });
+
+  describe("get", () => {
+    it("returns the attribute value", () => {
+      model = new CanonicalTestModel();
+      model.set({ one: "one" });
+      expect(model.get("one")).toEqual("one");
+    });
+  });
+
+  describe("set", () => {
+    describe("triggers an update", () => {
+      beforeEach(() => {
+        model = new CanonicalTestModel();
+        model.onUpdate(callback);
+      });
+
+      it("if a value has changed", () => {
+        model.set({ one: "one" }, context);
+        expect(callback).toHaveBeenCalledWith(model.toJSON(), context);
+        callback.mockClear();
+
+        model.set({ two: { three: "four" } }, context);
+        expect(callback).toHaveBeenCalledWith(model.toJSON(), context);
+        callback.mockClear();
+
+        model.set({ one: "one" });
+        expect(callback).not.toHaveBeenCalled();
+
+        model.set();
+        expect(callback).not.toHaveBeenCalled();
+
+        model.set({ one: null }, context, { unset: true });
+        expect(model.toJSON()).toEqual({ two: { three: "four" } });
+        expect(callback).toHaveBeenCalledWith(model.toJSON(), context);
+      });
+    });
+  });
+
+  describe("removeSubscription", () => {
+    const subscriberModel = new Model();
+
+    beforeEach(() => {
+      model = new CanonicalTestModel();
+      model.onUpdate(callback, subscriberModel);
+    });
+
+    it("removes the subscription from the canonical model", () => {
+      model.removeSubscription(subscriberModel, "1234");
+      model.set({ one: "one" }, subscriberModel);
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("removes the canonical model from the cache if there are no more subscriptions", () => {
+      vi.spyOn(CanonicalModelCache, "remove").mockReturnValue();
+
+      model.removeSubscription(subscriberModel, "1234");
+      expect(CanonicalModelCache.remove).toHaveBeenCalledWith(CanonicalTestModel, "1234");
+    });
+  });
+
+  describe("toJSON", () => {
+    it("returns a copy of the attributes", () => {
+      model = new CanonicalTestModel();
+      model.set({ one: "one" });
+
+      const json = model.toJSON();
+
+      json.one = "two";
+      expect(model.toJSON()).toEqual({ one: "one" });
+    });
+  });
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,6 @@
 import { Utils } from "../index";
 import {
+  getNestedValue,
   hasErrored,
   hasLoaded,
   isDeepEqual,
@@ -186,7 +187,7 @@ describe("Utils", () => {
 
       it("if the objects have equal values, deeply", () => {
         expect(
-          isDeepEqual({ one: "one", two: 2, three: null }, { one: "one", two: 2, three: null })
+          isDeepEqual({ one: "one", two: 2, three: null }, { one: "one", two: 2, three: null }),
         ).toBe(true);
         // nested
         expect(
@@ -198,8 +199,8 @@ describe("Utils", () => {
             {
               one: "one",
               two: { three: "three" },
-            }
-          )
+            },
+          ),
         ).toBe(true);
       });
     });
@@ -236,8 +237,8 @@ describe("Utils", () => {
             { name: "zorah" },
             { name: "alex" },
           ],
-          ({ name }) => name
-        )
+          ({ name }) => name,
+        ),
       ).toEqual([
         { name: "alex" },
         { name: "alex" },
@@ -250,6 +251,22 @@ describe("Utils", () => {
       ]);
 
       expect(sortBy()).toEqual([]);
+    });
+  });
+
+  describe("getNestedValue", () => {
+    it("gets a nested value from an object", () => {
+      expect(getNestedValue({ foo: { bar: "baz" } }, "foo.bar")).toEqual("baz");
+      expect(getNestedValue({ foo: "bar" }, "foo")).toEqual("bar");
+    });
+
+    it("returns undefined if the path is not found", () => {
+      expect(getNestedValue({ foo: { bar: "baz" } }, "foo.baz")).toBeUndefined();
+    });
+
+    it("returns undefined if the object is not an object", () => {
+      // this wouldn't pass types...
+      expect(getNestedValue(null, "foo.bar")).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Description of Proposed Changes:  
  -  Creates a CanonicalModel class, along with a CanonicalModelCache, both acting outside the React flow
  -  Adds a static `subscriptions` list for models to listen on canonical model changes and to update them
  -  This pub/sub architecture is on a model basis only, and assuming each model has their unique id per canonical model class, will keep unrelated UI components in sync when their subscribed models change.
