### PR TITLE
auto-set multipart header

### DIFF
--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -109,7 +109,11 @@ export function ajax(
         Accept: MIME_TYPE_JSON,
         // only set contentType header if a write request and if there is body params. also, default
         // to JSON contentTypes, but allow for it to be overridden, ie with x-www-form-urlencoded.
-        ...(hasBodyContent ? { "Content-Type": options.contentType } : {}),
+        // finally, let the browser auto-set multipart/form-data if a FormData object is passed in,
+        // because it'll also add the appropriate boundary string to the header.
+        ...(hasBodyContent && !(options.params instanceof FormData) ?
+          { "Content-Type": options.contentType }
+        : {}),
         ...options.headers,
       },
       ...(hasBodyContent ?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resourcerer",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resourcerer",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "devDependencies": {
         "@eslint/js": "^9.6.0",
         "@stylistic/eslint-plugin": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "repository": {
     "type": "git",
     "url": "github.com/noahgrant/resourcerer"

--- a/test/sync.test.js
+++ b/test/sync.test.js
@@ -22,7 +22,7 @@ describe("sync", () => {
   beforeEach(() => {
     library = new Library();
     vi.spyOn(window, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ test: "response!" }), { status: 200 })
+      new Response(JSON.stringify({ test: "response!" }), { status: 200 }),
     );
   });
 
@@ -93,6 +93,7 @@ describe("sync", () => {
     await library.at(0).save(null, { params: formData, contentType: "multipart/form-data" });
     expect(window.fetch.mock.calls[0][0]).toEqual("/library");
     expect(window.fetch.mock.calls[0][1].body).toEqual(formData);
+    expect(window.fetch.mock.calls[0][1].headers["Content-Type"]).not.toBeDefined();
   });
 
   it("passes urlOptions to the model to formulate the url path", async () => {
@@ -121,7 +122,7 @@ describe("sync", () => {
 
     librarySectionBook = new LibrarySectionBook(
       {},
-      { section: "nature", bookId: "all-about-frogs" }
+      { section: "nature", bookId: "all-about-frogs" },
     );
     await librarySectionBook.fetch({ params: { a: "a", one: 1 } });
     expect(window.fetch.mock.calls[2][0]).toEqual("/library/nature/all-about-frogs?a=a&one=1");
@@ -182,7 +183,7 @@ describe("sync", () => {
 
   it("rejects non-2xx", async () => {
     window.fetch.mockResolvedValue(
-      new Response(JSON.stringify({ test: "womp" }), { status: 500, type: "application/json" })
+      new Response(JSON.stringify({ test: "womp" }), { status: 500, type: "application/json" }),
     );
 
     try {


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

Fixes the issue where formData could not be sent without a `contentType` header, which prohibits the browser from sending its own with its own boundary parameter.