### PR TITLE
declare url property on collection

### DIFF
--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -142,6 +142,8 @@ export default class Collection<
    */
   static measure: boolean | ((config: ResourceConfigObj) => boolean) = false;
 
+  declare url: (options: typeof this.urlOptions) => string;
+
   /**
    * Similar to the method for an individual model, this maps through each model in the collection
    * and returns its data attributes.


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

- uses `declare` keyword to define a `url` function on the `Collection` class without compiling to any runtime values.
