### PR TITLE
add exports type map to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcerer",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "repository": {
     "type": "git",
     "url": "github.com/noahgrant/resourcerer"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,12 @@
     "test:coverage": "vitest run --coverage",
     "test:debug": "vitest --inspect-brk --pool threads --poolOptions.threads.singleThread run"
   },
-  "exports": "./build/index.js",
+  "exports": {
+    ".": {
+      "types": "./resourcerer.d.ts",
+      "import": "./build/index.js"
+    }
+  },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
Expands the exports field in package.json from a bare string to a subpath map:
 
```                                                            
  "exports": {    
    ".": {                                                         
      "types": "./resourcerer.d.ts",                               
      "import": "./build/index.js"
    }
  }                                                                
 ```

 This allows TypeScript-aware bundlers and Node's package  resolution to discover types automatically via the exports map,
  rather than relying solely on the top-level "types" field. Better compatibility with tools that honor exports conditions (e.g.
  TypeScript's moduleResolution: bundler or node16).