### PR TITLE
Cascade destroy peer collections

### DIFF
--- a/lib/canonical-model.ts
+++ b/lib/canonical-model.ts
@@ -56,14 +56,14 @@ export default class CanonicalModel<T extends Record<string, any>> extends Event
    * collection class from their collections, since we know it must no longer exist.
    * This keeps peer collection instances in sync.
    */
-  removeSubscribersFromCollection(collectionClass: CollectionConstructor, source: Model<any, any>) {
+  removeSubscribersFromCollection(CollectionClass: CollectionConstructor, source: Model<any, any>) {
     for (const { context } of this._callbacks) {
       const model = context as Model<any, any>;
 
       if (
         model !== source &&
         model.collection &&
-        model.collection.constructor === collectionClass
+        model.collection.constructor === CollectionClass
       ) {
         model.collection.remove(model);
       }

--- a/lib/canonical-model.ts
+++ b/lib/canonical-model.ts
@@ -1,6 +1,7 @@
 import { isDeepEqual } from "./utils.js";
 import Events from "./events.js";
 import Model from "./model.js";
+import { type CollectionConstructor } from "./collection.js";
 import CanonicalModelCache from "./canonical-model-cache.js";
 
 /**
@@ -47,6 +48,25 @@ export default class CanonicalModel<T extends Record<string, any>> extends Event
       // the context is important here - we don't want to update the same model that just
       // set the canonical model's attributes in the first place
       this.triggerUpdate(this.toJSON(), context);
+    }
+  }
+
+  /**
+   * When a model is destroyed, remove any other subscribing models that belong to the same
+   * collection class from their collections, since we know it must no longer exist.
+   * This keeps peer collection instances in sync.
+   */
+  removeSubscribersFromCollection(collectionClass: CollectionConstructor, source: Model<any, any>) {
+    for (const { context } of this._callbacks) {
+      const model = context as Model<any, any>;
+
+      if (
+        model !== source &&
+        model.collection &&
+        model.collection.constructor === collectionClass
+      ) {
+        model.collection.remove(model);
+      }
     }
   }
 

--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -591,3 +591,5 @@ export default class Collection<
     }
   }
 }
+
+export type CollectionConstructor = abstract new (...args: any[]) => Collection;

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -2,7 +2,7 @@ import { getNestedValue, isDeepEqual, result, uniqueId, urlError } from "./utils
 
 import Events from "./events.js";
 import sync, { type SyncOptions } from "./sync.js";
-import Collection from "./collection.js";
+import Collection, { type CollectionConstructor } from "./collection.js";
 import { NestedKeys, ResourceConfigObj } from "./types.js";
 import CanonicalModel from "./canonical-model.js";
 import CanonicalModelCache from "./canonical-model-cache.js";
@@ -346,9 +346,10 @@ export default class Model<
           Promise.resolve([])
         : this.sync(this as Model | Collection, { method: "DELETE", ...options }),
       collection = this.collection;
+    // store as a variable because once removed, there is no collection field on the model
+    const CollectionClass = collection?.constructor as CollectionConstructor | undefined;
 
     if (!options.wait) {
-      this.triggerUpdate();
       this.collection?.remove(this, { silent: true });
     }
 
@@ -357,6 +358,10 @@ export default class Model<
         if (options.wait && !this.isNew()) {
           this.triggerUpdate();
           this.collection?.remove(this, { silent: true });
+        }
+
+        if (!this.isNew()) {
+          this._removePeerSubscribers(CollectionClass);
         }
 
         // model orphans with subscriptions will never have a chance to unsubscribe automatically.
@@ -476,9 +481,36 @@ export default class Model<
   }
 
   /**
-   * This will get called when this model is set. It then needs to update any canonical models
-   * it is subscribed to.
+   * When a model with subscriptions is deleted, we know that we can remove any model with that id
+   * from an identical Collection class (think of two Collection instances that are filtered
+   * differently).
+   *
+   * We do have to run through our subscriptions and pick out our CanonicalModel class. It could be
+   * as easy as a static CanonicalModel property. Or it could be in our subscriptions array.
    */
+  _removePeerSubscribers(CollectionClass?: CollectionConstructor) {
+    if (!CollectionClass) {
+      return;
+    }
+
+    const subscriptions = this._getSubscriptions();
+    const idAttribute = (this.constructor as typeof Model).idAttribute;
+
+    for (const { Model: CanonicalModel, idField = idAttribute } of subscriptions) {
+      if (idField !== idAttribute) {
+        continue;
+      }
+
+      const id = getNestedValue(this.toJSON(), idField);
+
+      if (id && !this.isEmptyModel) {
+        const canonicalModel = CanonicalModelCache.getOrInsert(CanonicalModel, id);
+
+        canonicalModel.removeSubscribersFromCollection(CollectionClass, this);
+      }
+    }
+  }
+
   _updateSubscriptions(attrs: Partial<T> = {}, options: SetOptions = {}): void {
     const subscriptions = this._getSubscriptions();
     const idAttribute = (this.constructor as typeof Model).idAttribute;

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -350,6 +350,7 @@ export default class Model<
     const CollectionClass = collection?.constructor as CollectionConstructor | undefined;
 
     if (!options.wait) {
+      this.triggerUpdate();
       this.collection?.remove(this, { silent: true });
     }
 

--- a/test/canonical-model.test.js
+++ b/test/canonical-model.test.js
@@ -1,4 +1,5 @@
-import CanonicalModelCache from "../lib/canonical-model-cache";
+import CanonicalModelCache, { canonicalModelCache } from "../lib/canonical-model-cache";
+import Collection from "../lib/collection";
 import Model from "../lib/model";
 import { vi } from "vitest";
 import CanonicalModel from "../lib/canonical-model";
@@ -12,6 +13,7 @@ describe("CanonicalModel", () => {
 
   afterEach(() => {
     callback.mockClear();
+    canonicalModelCache.clear();
   });
 
   describe("get", () => {
@@ -48,6 +50,38 @@ describe("CanonicalModel", () => {
         expect(model.toJSON()).toEqual({ two: { three: "four" } });
         expect(callback).toHaveBeenCalledWith(model.toJSON(), context);
       });
+    });
+  });
+
+  describe("removeSubscribersFromCollection", () => {
+    class UsersCollection extends Collection {
+      url() {
+        return "/users";
+      }
+    }
+
+    class UserDetailsCollection extends Collection {
+      url() {
+        return "/user-details";
+      }
+    }
+
+    it("removes peer models from the same collection class but not other collection classes", () => {
+      const canonicalModel = new CanonicalTestModel();
+      const activeUsers = new UsersCollection([{ id: "1234" }]);
+      const allUsers = new UsersCollection([{ id: "1234" }]);
+      const userDetails = new UserDetailsCollection([{ id: "1234" }]);
+      const source = activeUsers.get("1234");
+
+      canonicalModel.onUpdate(() => {}, activeUsers.get("1234"));
+      canonicalModel.onUpdate(() => {}, allUsers.get("1234"));
+      canonicalModel.onUpdate(() => {}, userDetails.get("1234"));
+
+      canonicalModel.removeSubscribersFromCollection(UsersCollection, source);
+
+      expect(activeUsers.has("1234")).toBe(true);
+      expect(allUsers.has("1234")).toBe(false);
+      expect(userDetails.has("1234")).toBe(true);
     });
   });
 

--- a/test/canonical-model.test.js
+++ b/test/canonical-model.test.js
@@ -55,12 +55,16 @@ describe("CanonicalModel", () => {
 
   describe("removeSubscribersFromCollection", () => {
     class UsersCollection extends Collection {
+      static CanonicalModel = CanonicalTestModel;
+
       url() {
         return "/users";
       }
     }
 
     class UserDetailsCollection extends Collection {
+      static CanonicalModel = CanonicalTestModel;
+
       url() {
         return "/user-details";
       }
@@ -79,6 +83,7 @@ describe("CanonicalModel", () => {
 
       canonicalModel.removeSubscribersFromCollection(UsersCollection, source);
 
+      // we didn't actually remove it from this collection, it's jus the source
       expect(activeUsers.has("1234")).toBe(true);
       expect(allUsers.has("1234")).toBe(false);
       expect(userDetails.has("1234")).toBe(true);

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -73,7 +73,7 @@ describe("Events", () => {
       var request;
 
       request = model.destroy();
-      expect(callback).toHaveBeenCalled();
+      expect(callback).not.toHaveBeenCalled();
 
       await request;
       expect(callback).toHaveBeenCalledTimes(1);
@@ -82,8 +82,7 @@ describe("Events", () => {
       sync.default.mockRejectedValue({});
 
       await model.destroy().catch(() => false);
-      // gets called when model is added back to collection
-      expect(callback).toHaveBeenCalled();
+      expect(callback).not.toHaveBeenCalled();
       callback.mockClear();
 
       await model.destroy({ wait: true }).catch(() => false);

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -73,7 +73,7 @@ describe("Events", () => {
       var request;
 
       request = model.destroy();
-      expect(callback).not.toHaveBeenCalled();
+      expect(callback).toHaveBeenCalled();
 
       await request;
       expect(callback).toHaveBeenCalledTimes(1);
@@ -82,7 +82,8 @@ describe("Events", () => {
       sync.default.mockRejectedValue({});
 
       await model.destroy().catch(() => false);
-      expect(callback).not.toHaveBeenCalled();
+      // gets called when model is added back to collection
+      expect(callback).toHaveBeenCalled();
       callback.mockClear();
 
       await model.destroy({ wait: true }).catch(() => false);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -387,7 +387,7 @@ describe("Model", () => {
       }
     });
 
-    it("updates immediately if `wait` is false", async () => {
+    it("removes from the collection immediately if `wait` is false", async () => {
       var request;
 
       collection = new Collection([model]);
@@ -396,9 +396,11 @@ describe("Model", () => {
 
       request = model.destroy();
 
-      expect(callback).toHaveBeenCalled();
+      expect(callback).not.toHaveBeenCalled();
       expect(collection.has(model.id)).toBe(false);
       await request;
+
+      expect(callback).toHaveBeenCalled();
     });
 
     it("updates when the promise resolves if `wait` is true", async () => {
@@ -432,14 +434,15 @@ describe("Model", () => {
 
       request = model.destroy();
 
-      expect(callback).toHaveBeenCalled();
-      expect(collectionCallback).toHaveBeenCalled();
+      expect(callback).not.toHaveBeenCalled();
+      expect(collectionCallback).not.toHaveBeenCalled();
       expect(collection.has(model.id)).toBe(false);
 
       try {
         await request;
       } catch (err) {
-        expect(collectionCallback).toHaveBeenCalledTimes(2);
+        expect(callback).not.toHaveBeenCalled();
+        expect(collectionCallback).toHaveBeenCalledTimes(1);
         expect(collection.has(model.id)).toBe(true);
         expect(err).toEqual(response);
       }
@@ -453,6 +456,108 @@ describe("Model", () => {
         expect(collection.has(model.id)).toBe(true);
         expect(err).toEqual(response);
       }
+    });
+
+    describe("peer collections", () => {
+      class CanonicalUserModel extends CanonicalModel {}
+
+      class UsersCollection extends Collection {
+        static CanonicalModel = CanonicalUserModel;
+      }
+
+      class UserDetailsCollection extends Collection {
+        static CanonicalModel = CanonicalUserModel;
+      }
+
+      beforeEach(() => {
+        canonicalModelCache.clear();
+      });
+
+      afterEach(() => {
+        canonicalModelCache.clear();
+      });
+
+      it("removes the model from other instances of the same collection class after DELETE succeeds", async () => {
+        const activeUsers = new UsersCollection([{ id: "1234", name: "Bob" }]);
+        const allUsers = new UsersCollection([{ id: "1234", name: "Bob" }]);
+        const userDetails = new UserDetailsCollection([{ id: "1234", name: "Bob" }]);
+
+        model = activeUsers.get("1234");
+        await model.destroy();
+
+        expect(allUsers.has("1234")).toBe(false);
+        expect(userDetails.has("1234")).toBe(true);
+      });
+
+      it("removes peers only after the request resolves when `wait` is true", async () => {
+        const activeUsers = new UsersCollection([{ id: "1234", name: "Bob" }]);
+        const allUsers = new UsersCollection([{ id: "1234", name: "Bob" }]);
+
+        model = activeUsers.get("1234");
+        const request = model.destroy({ wait: true });
+
+        expect(allUsers.has("1234")).toBe(true);
+        await request;
+        expect(allUsers.has("1234")).toBe(false);
+      });
+
+      it("does not remove peers when the request rejects", async () => {
+        sync.default.mockRejectedValue(response);
+
+        const activeUsers = new UsersCollection([{ id: "1234", name: "Bob" }]);
+        const allUsers = new UsersCollection([{ id: "1234", name: "Bob" }]);
+
+        model = activeUsers.get("1234");
+
+        try {
+          await model.destroy();
+        } catch (err) {
+          expect(allUsers.has("1234")).toBe(true);
+          expect(err).toEqual(response);
+        }
+      });
+
+      it("removes peers when the canonical model is defined on the model subscriptions", async () => {
+        class User extends Model {
+          static subscriptions = [
+            {
+              Model: CanonicalUserModel,
+              toSource: (attrs) => attrs,
+              fromSource: (attrs) => attrs,
+            },
+          ];
+        }
+
+        class SubscriptionsUsersCollection extends Collection {
+          static Model = User;
+        }
+
+        const activeUsers = new SubscriptionsUsersCollection([{ id: "1234", name: "Bob" }]);
+        const allUsers = new SubscriptionsUsersCollection([{ id: "1234", name: "Bob" }]);
+
+        model = activeUsers.get("1234");
+        await model.destroy();
+
+        expect(allUsers.has("1234")).toBe(false);
+      });
+
+      it("removes peers when the canonical model is defined on the model class", async () => {
+        class User extends Model {
+          static CanonicalModel = CanonicalUserModel;
+        }
+
+        class ModelUsersCollection extends Collection {
+          static Model = User;
+        }
+
+        const activeUsers = new ModelUsersCollection([{ id: "1234", name: "Bob" }]);
+        const allUsers = new ModelUsersCollection([{ id: "1234", name: "Bob" }]);
+
+        model = activeUsers.get("1234");
+        await model.destroy();
+
+        expect(allUsers.has("1234")).toBe(false);
+      });
     });
   });
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -387,7 +387,7 @@ describe("Model", () => {
       }
     });
 
-    it("removes from the collection immediately if `wait` is false", async () => {
+    it("updates immediately if `wait` is false", async () => {
       var request;
 
       collection = new Collection([model]);
@@ -396,11 +396,9 @@ describe("Model", () => {
 
       request = model.destroy();
 
-      expect(callback).not.toHaveBeenCalled();
+      expect(callback).toHaveBeenCalled();
       expect(collection.has(model.id)).toBe(false);
       await request;
-
-      expect(callback).toHaveBeenCalled();
     });
 
     it("updates when the promise resolves if `wait` is true", async () => {
@@ -434,15 +432,14 @@ describe("Model", () => {
 
       request = model.destroy();
 
-      expect(callback).not.toHaveBeenCalled();
-      expect(collectionCallback).not.toHaveBeenCalled();
+      expect(callback).toHaveBeenCalled();
+      expect(collectionCallback).toHaveBeenCalled();
       expect(collection.has(model.id)).toBe(false);
 
       try {
         await request;
       } catch (err) {
-        expect(callback).not.toHaveBeenCalled();
-        expect(collectionCallback).toHaveBeenCalledTimes(1);
+        expect(collectionCallback).toHaveBeenCalledTimes(2);
         expect(collection.has(model.id)).toBe(true);
         expect(err).toEqual(response);
       }
@@ -463,15 +460,19 @@ describe("Model", () => {
 
       class UsersCollection extends Collection {
         static CanonicalModel = CanonicalUserModel;
+
+        url() {
+          return "/users";
+        }
       }
 
       class UserDetailsCollection extends Collection {
         static CanonicalModel = CanonicalUserModel;
-      }
 
-      beforeEach(() => {
-        canonicalModelCache.clear();
-      });
+        url() {
+          return "/user-details";
+        }
+      }
 
       afterEach(() => {
         canonicalModelCache.clear();
@@ -482,9 +483,9 @@ describe("Model", () => {
         const allUsers = new UsersCollection([{ id: "1234", name: "Bob" }]);
         const userDetails = new UserDetailsCollection([{ id: "1234", name: "Bob" }]);
 
-        model = activeUsers.get("1234");
-        await model.destroy();
+        await activeUsers.get("1234").destroy();
 
+        expect(activeUsers.has("1234")).toBe(false);
         expect(allUsers.has("1234")).toBe(false);
         expect(userDetails.has("1234")).toBe(true);
       });
@@ -530,6 +531,74 @@ describe("Model", () => {
 
         class SubscriptionsUsersCollection extends Collection {
           static Model = User;
+        }
+
+        const activeUsers = new SubscriptionsUsersCollection([{ id: "1234", name: "Bob" }]);
+        const allUsers = new SubscriptionsUsersCollection([{ id: "1234", name: "Bob" }]);
+
+        model = activeUsers.get("1234");
+        await model.destroy();
+
+        expect(allUsers.has("1234")).toBe(false);
+      });
+
+      it("does not remove peers when the canonical model id field and idAttribute are not equal", async () => {
+        class User extends Model {
+          static subscriptions = [
+            {
+              Model: CanonicalUserModel,
+              idField: "_id",
+              toSource: (attrs) => attrs,
+              fromSource: (attrs) => attrs,
+            },
+          ];
+        }
+
+        class SubscriptionsUsersCollection extends Collection {
+          static Model = User;
+        }
+
+        const activeUsers = new SubscriptionsUsersCollection([{ id: "1234", name: "Bob" }]);
+        const allUsers = new SubscriptionsUsersCollection([{ id: "1234", name: "Bob" }]);
+
+        model = activeUsers.get("1234");
+        await model.destroy();
+
+        // canonical model subscription has an id field that does not equal idAttribute,
+        // so it is not removed
+        expect(allUsers.has("1234")).toBe(true);
+      });
+
+      it("removes peers when the canonical model id field and idAttribute are not the default 'id'", async () => {
+        class User extends Model {
+          static subscriptions = [
+            {
+              Model: CanonicalUserModel,
+              idField: "_id",
+              toSource: (attrs) => attrs,
+              fromSource: (attrs) => attrs,
+            },
+          ];
+
+          static idAttribute = "_id";
+        }
+
+        class SubscriptionsUsersCollection extends Collection {
+          static Model = User;
+        }
+
+        const activeUsers = new SubscriptionsUsersCollection([{ _id: "1234", name: "Bob" }]);
+        const allUsers = new SubscriptionsUsersCollection([{ _id: "1234", name: "Bob" }]);
+
+        model = activeUsers.get("1234");
+        await model.destroy();
+
+        expect(allUsers.has("1234")).toBe(false);
+      });
+
+      it("removes peers when the canonical model is defined on the collection", async () => {
+        class SubscriptionsUsersCollection extends Collection {
+          static CanonicalModel = CanonicalUserModel;
         }
 
         const activeUsers = new SubscriptionsUsersCollection([{ id: "1234", name: "Bob" }]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "strictPropertyInitialization": false,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "noImplicitOverride": false,
     "noImplicitReturns": false,
     "noImplicitThis": true,


### PR DESCRIPTION
## Fixes (includes issue number if applicable):

When a model is destroyed, subscribing models from an identical Collection class will get removed from their collections, as well.
