### PR TITLE
Add static invalidates property to Model and Collection

### DIFF
--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -7,7 +7,7 @@ import Model, {
   type SetOptions,
 } from "./model.js";
 import sync, { type SyncOptions } from "./sync.js";
-import { ResourceConfigObj } from "./types.js";
+import { ResourceConfigObj, ResourceKeys } from "./types.js";
 import CanonicalModelConstructor from "./canonical-model.js";
 
 type CSetOptions = {
@@ -141,6 +141,12 @@ export default class Collection<
    * boolean. If the latter, it takes a the resource config object as an argument.
    */
   static measure: boolean | ((config: ResourceConfigObj) => boolean) = false;
+
+  /**
+   * Use this to list resource keys that should be invalidated from the ModelCache after any
+   * successful write request (save or destroy) on a model belonging to this collection.
+   */
+  static invalidates: ResourceKeys[] = [];
 
   /**
    * Similar to the method for an individual model, this maps through each model in the collection

--- a/lib/model-cache.ts
+++ b/lib/model-cache.ts
@@ -1,6 +1,6 @@
 import { ResourcesConfig } from "./config.js";
-import Collection from "./collection.js";
-import Model from "./model.js";
+import type Collection from "./collection.js";
+import type Model from "./model.js";
 import { ResourceKeys } from "./types.js";
 
 type Component = NonNullable<unknown>;

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -3,7 +3,8 @@ import { getNestedValue, isDeepEqual, result, uniqueId, urlError } from "./utils
 import Events from "./events.js";
 import sync, { type SyncOptions } from "./sync.js";
 import Collection, { type CollectionConstructor } from "./collection.js";
-import { NestedKeys, ResourceConfigObj } from "./types.js";
+import { NestedKeys, ResourceConfigObj, ResourceKeys } from "./types.js";
+import { invalidate } from "./model-cache.js";
 import CanonicalModel from "./canonical-model.js";
 import CanonicalModelCache from "./canonical-model-cache.js";
 
@@ -152,6 +153,15 @@ export default class Model<
   static subscriptions: CanonicalModelSubscription[] = [];
 
   static CanonicalModel: (new (...args: any[]) => CanonicalModel<any>) | null = null;
+
+  /**
+   * Use this to list resource keys that should be invalidated from the ModelCache after any
+   * successful write request (save or destroy) on this model or its parent collection. Because
+   * invalidation and refetch can happen in the same JS stack, the invalidation is deferred via
+   * setTimeout so that any refetch() calls in the same .then() chain can still find the model
+   * in the cache before it is removed.
+   */
+  static invalidates: ResourceKeys[] = [];
 
   /**
    * Returns a copy of the model's `attributes` object. Use this method to get the current entire
@@ -320,6 +330,7 @@ export default class Model<
         this.set(serverAttrs, { silent: true, ...options });
         // sync update
         this.triggerUpdate();
+        this._invalidateRelated();
 
         return [this, response] as [this, Response];
       })
@@ -367,6 +378,7 @@ export default class Model<
 
         // model orphans with subscriptions will never have a chance to unsubscribe automatically.
         this.unsubscribe();
+        this._invalidateRelated();
 
         return [this, response] as [this, Response];
       })
@@ -530,6 +542,19 @@ export default class Model<
           options,
         );
       }
+    }
+  }
+
+  _invalidateRelated() {
+    const keys = [
+      ...(this.constructor as typeof Model).invalidates,
+      ...((this.collection?.constructor as typeof Collection)?.invalidates ?? []),
+    ];
+
+    if (keys.length) {
+      // Defer so that any refetch() calls made by user code in the same .then()
+      // chain can still find the model in the cache before we remove it.
+      window.setTimeout(() => invalidate(keys), 0);
     }
   }
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1,4 +1,5 @@
 import * as sync from "../lib/sync";
+import * as modelCache from "../lib/model-cache";
 import CanonicalModel from "../lib/canonical-model";
 import { canonicalModelCache } from "../lib/canonical-model-cache";
 
@@ -1154,6 +1155,126 @@ describe("Model", () => {
           fromSource: expect.any(Function),
         },
       ]);
+    });
+  });
+
+  describe("invalidates", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.spyOn(modelCache, "invalidate");
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      modelCache.invalidate.mockRestore();
+    });
+
+    it("has an empty invalidates list by default", () => {
+      expect(Model.invalidates).toEqual([]);
+    });
+
+    it("does not call invalidate after save when invalidates is empty", async () => {
+      model = new Model();
+      await model.save();
+      vi.runAllTimers();
+      expect(modelCache.invalidate).not.toHaveBeenCalled();
+    });
+
+    it("calls invalidate with the model's invalidates keys after a successful save", async () => {
+      class _Model extends Model {
+        static invalidates = ["todos", "user"];
+      }
+
+      model = new _Model();
+      await model.save();
+      expect(modelCache.invalidate).not.toHaveBeenCalled();
+
+      vi.runAllTimers();
+      expect(modelCache.invalidate).toHaveBeenCalledWith(["todos", "user"]);
+    });
+
+    it("calls invalidate with the model's invalidates keys after a successful destroy", async () => {
+      class _Model extends Model {
+        static invalidates = ["todos"];
+      }
+
+      model = new _Model({ id: "1234" });
+      await model.destroy();
+      expect(modelCache.invalidate).not.toHaveBeenCalled();
+
+      vi.runAllTimers();
+      expect(modelCache.invalidate).toHaveBeenCalledWith(["todos"]);
+    });
+
+    it("does not call invalidate after a failed save", async () => {
+      class _Model extends Model {
+        static invalidates = ["todos"];
+      }
+
+      sync.default.mockRejectedValue(new Error("failed"));
+      model = new _Model();
+
+      try {
+        await model.save();
+      } catch (_) {
+        // expected
+      }
+
+      vi.runAllTimers();
+      expect(modelCache.invalidate).not.toHaveBeenCalled();
+    });
+
+    it("does not call invalidate after a failed destroy", async () => {
+      class _Model extends Model {
+        static invalidates = ["todos"];
+      }
+
+      sync.default.mockRejectedValue(new Error("failed"));
+      model = new _Model({ id: "1234" });
+
+      try {
+        await model.destroy();
+      } catch (_) {
+        // expected
+      }
+
+      vi.runAllTimers();
+      expect(modelCache.invalidate).not.toHaveBeenCalled();
+    });
+
+    it("includes invalidates keys from the parent collection", async () => {
+      class _Model extends Model {
+        static invalidates = ["todos"];
+      }
+
+      class _Collection extends Collection {
+        static invalidates = ["user"];
+      }
+
+      collection = new _Collection();
+      model = new _Model({ id: "1234" }, { collection });
+      await model.save();
+      vi.runAllTimers();
+      expect(modelCache.invalidate).toHaveBeenCalledWith(["todos", "user"]);
+    });
+
+    it("defers invalidation so refetch can still find the model in the same .then() chain", async () => {
+      class _Model extends Model {
+        static invalidates = ["todos"];
+      }
+
+      model = new _Model();
+
+      let modelStillInCacheDuringSave = false;
+
+      await model.save().then(() => {
+        modelStillInCacheDuringSave = true;
+        expect(modelCache.invalidate).not.toHaveBeenCalled();
+      });
+
+      expect(modelStillInCacheDuringSave).toBe(true);
+      vi.runAllTimers();
+      expect(modelCache.invalidate).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
When populated, automatically invalidates those resource keys from the ModelCache after any successful save or destroy. Invalidation is deferred via setTimeout so that refetch() calls in the same .then() chain can still find the model in the cache before it is removed.

